### PR TITLE
feat: bundle fixes

### DIFF
--- a/api/artifacts/[package]/[version]/[filename].js
+++ b/api/artifacts/[package]/[version]/[filename].js
@@ -80,17 +80,26 @@ module.exports = async function handler(req, res) {
 
   try {
     const store = getStorage();
-    const binaryHex = await store.getBundleBinary(pkg, version);
+    const [binaryHex, manifest] = await Promise.all([
+      store.getBundleBinary(pkg, version),
+      store.getBundleManifest(pkg, version),
+    ]);
 
     if (!binaryHex) {
-      return res.status(404).json({
-        error: 'artifact_not_found',
-        message: `Binary for ${pkg}@${version} not found in storage`,
+      if (!manifest) {
+        return res.status(404).json({
+          error: 'artifact_not_found',
+          message: `${pkg}@${version} not found`,
+        });
+      }
+      return res.status(409).json({
+        error: 'binary_missing',
+        message: `Manifest for ${pkg}@${version} exists but binary was never uploaded. Re-publish the bundle.`,
+        manifest,
       });
     }
 
     // Expose min_runtime_version for runtime compatibility (Rust expects this)
-    const manifest = await store.getBundleManifest(pkg, version);
     const minRuntimeVersion =
       manifest?.minRuntimeVersion ?? manifest?.min_runtime_version;
     const minRuntimeVersionHeader =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `GET /api/artifacts/:package/:version/:filename` response semantics for missing binaries vs missing artifacts, which may affect clients relying on previous `404` behavior. Otherwise the change is small and limited to this endpoint.
> 
> **Overview**
> Updates the artifact download endpoint to fetch the bundle `manifest` and binary in parallel and to **differentiate missing states**.
> 
> When the binary is missing, the API now returns `404` only if the *entire artifact* is absent, and returns `409` with a `binary_missing` error (including the manifest) when a manifest exists but the binary was never uploaded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba7ba3c9b52059ad90b081ac07d4bdc95922013b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->