### PR TITLE
fix: ws error

### DIFF
--- a/api/artifacts/[package]/[version]/[filename].js
+++ b/api/artifacts/[package]/[version]/[filename].js
@@ -43,10 +43,11 @@ module.exports = async function handler(req, res) {
   // If parameters are missing or contain literal "$package" (Vercel rewrite issue),
   // parse from URL path
   if (!pkg || !version || pkg === '$package' || version === '$version') {
-    const url = req.url || '';
+    // Strip query string from URL path before matching
+    const urlPath = (req.url || '').split('?')[0];
     // Match both /api/artifacts/... and /artifacts/... patterns
     // Also handle cases where the URL might be the rewritten path
-    const match = url.match(
+    const match = urlPath.match(
       /\/(?:api\/)?artifacts\/([^\/]+)\/([^\/]+)\/([^\/]+)/
     );
     if (match) {

--- a/packages/backend/src/lib/kv-client.js
+++ b/packages/backend/src/lib/kv-client.js
@@ -40,16 +40,19 @@ if (isProduction && process.env.REDIS_URL) {
         await redisClient.quit().catch(() => {});
         this._connected = false;
       }
-      this._connectingPromise = redisClient.connect().then(() => {
-        this._connected = true;
-        this._connectingPromise = null;
-        // eslint-disable-next-line no-console
-        console.log('✅ Connected to Vercel Marketplace Redis');
-      }).catch(err => {
-        this._connectingPromise = null;
-        this._connected = false;
-        throw err;
-      });
+      this._connectingPromise = redisClient
+        .connect()
+        .then(() => {
+          this._connected = true;
+          this._connectingPromise = null;
+          // eslint-disable-next-line no-console
+          console.log('✅ Connected to Vercel Marketplace Redis');
+        })
+        .catch(err => {
+          this._connectingPromise = null;
+          this._connected = false;
+          throw err;
+        });
       await this._connectingPromise;
     },
 

--- a/packages/backend/src/lib/kv-client.js
+++ b/packages/backend/src/lib/kv-client.js
@@ -27,14 +27,30 @@ if (isProduction && process.env.REDIS_URL) {
   // Wrapper to ensure connection before operations
   kvClient = {
     _connected: false,
+    _connectingPromise: null,
 
     async _ensureConnected() {
-      if (!this._connected) {
-        await redisClient.connect();
+      if (this._connected && redisClient.isReady) return;
+      if (this._connectingPromise) {
+        await this._connectingPromise;
+        return;
+      }
+      // If socket is open but not ready (e.g. after a timeout), force-close it first
+      if (redisClient.isOpen) {
+        await redisClient.quit().catch(() => {});
+        this._connected = false;
+      }
+      this._connectingPromise = redisClient.connect().then(() => {
         this._connected = true;
+        this._connectingPromise = null;
         // eslint-disable-next-line no-console
         console.log('✅ Connected to Vercel Marketplace Redis');
-      }
+      }).catch(err => {
+        this._connectingPromise = null;
+        this._connected = false;
+        throw err;
+      });
+      await this._connectingPromise;
     },
 
     // String operations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes connection management for the production Redis client and request URL parsing for the artifact download endpoint; mistakes could cause new Redis connection errors or mis-routing of artifact requests in production.
> 
> **Overview**
> Fixes artifact downloads when Vercel rewrites include a query string by stripping `?…` before regex-parsing `pkg/version/filename` from `req.url` in `api/artifacts/[package]/[version]/[filename].js`.
> 
> Hardens `packages/backend/src/lib/kv-client.js` connection handling by serializing concurrent connects via `_connectingPromise`, short-circuiting when `isReady`, and force-closing an open-but-not-ready socket before reconnecting to reduce intermittent Redis/WS errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41f381a7e999ca0e97372d8bec6bcbfb15ad75b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->