### PR TITLE
feat: add download counters app marketplace

### DIFF
--- a/packages/backend/src/lib/kv-client.js
+++ b/packages/backend/src/lib/kv-client.js
@@ -82,6 +82,11 @@ if (isProduction && process.env.REDIS_URL) {
       return await redisClient.del(key);
     },
 
+    async incr(key) {
+      await this._ensureConnected();
+      return await redisClient.incr(key);
+    },
+
     // Hash operations
     async hSet(key, obj) {
       await this._ensureConnected();
@@ -163,6 +168,13 @@ if (isProduction && process.env.REDIS_URL) {
       const existed = mockStore.has(key);
       mockStore.delete(key);
       return existed ? 1 : 0;
+    },
+
+    async incr(key) {
+      const current = parseInt(mockStore.get(key) || '0', 10);
+      const next = current + 1;
+      mockStore.set(key, String(next));
+      return next;
     },
 
     // Hash operations

--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -355,16 +355,27 @@ async function buildServer() {
           }
 
           const normalized = normalizeBundle(bundle);
-          normalized.downloads =
-            Number(await kv.get(`downloads:${packageName}`)) || 0;
-          bundles.push(normalized);
+          bundles.push({ normalized, packageName });
         }
       }
 
-      // Sort by package name
-      bundles.sort((a, b) => a.package.localeCompare(b.package));
+      // Batch Redis reads for download counts (one per unique package)
+      const uniquePackages = [...new Set(bundles.map(b => b.packageName))];
+      const downloadCounts = await Promise.all(
+        uniquePackages.map(p => kv.get(`downloads:${p}`))
+      );
+      const countByPackage = Object.fromEntries(
+        uniquePackages.map((p, i) => [p, Number(downloadCounts[i]) || 0])
+      );
+      const result = bundles.map(({ normalized, packageName }) => {
+        normalized.downloads = countByPackage[packageName] ?? 0;
+        return normalized;
+      });
 
-      return bundles;
+      // Sort by package name
+      result.sort((a, b) => a.package.localeCompare(b.package));
+
+      return result;
     } catch (error) {
       server.log.error('Error listing bundles:', error);
       return reply.code(500).send({
@@ -896,13 +907,15 @@ async function buildServer() {
       );
       reply.header('Content-Length', fileContent.length);
 
-      // Track installs — only count actual app bundles, not raw WASM dev files
-      if (ext === '.mpk' || ext === '.wasm') {
+      // Track installs — only count actual app bundles (.mpk), not raw WASM dev files
+      if (ext === '.mpk') {
         const parts = artifactPath.split('/');
         // Nested path: {package}/{version}/{filename} — extract package name
         const packageName = parts.length >= 3 ? parts[0] : null;
-        kv.incr('downloads:total').catch(() => {});
-        if (packageName) kv.incr(`downloads:${packageName}`).catch(() => {});
+        if (packageName) {
+          kv.incr('downloads:total').catch(() => {});
+          kv.incr(`downloads:${packageName}`).catch(() => {});
+        }
       }
 
       return reply.send(fileContent);

--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -15,6 +15,7 @@ const tar = require('tar');
 // Import config
 const config = require('./config');
 const { BundleStorageKV } = require('./lib/bundle-storage-kv');
+const { kv } = require('./lib/kv-client');
 const {
   verifyManifest,
   getPublicKeyFromManifest,
@@ -118,7 +119,7 @@ async function buildServer() {
         uniquePackages,
         publishedApps: uniquePackages,
         activeDevelopers: developers.size,
-        totalDownloads: 0, // TODO: Implement download tracking
+        totalDownloads: Number(await kv.get('downloads:total')) || 0,
       };
     } catch (error) {
       server.log.error('Error in GET /stats:', error);
@@ -301,7 +302,9 @@ async function buildServer() {
             message: `Bundle ${pkg}@${version} not found`,
           });
         }
-        return [normalizeBundle(bundle)];
+        const normalized = normalizeBundle(bundle);
+        normalized.downloads = Number(await kv.get(`downloads:${pkg}`)) || 0;
+        return [normalized];
       }
 
       // Get all bundle packages
@@ -351,7 +354,9 @@ async function buildServer() {
             }
           }
 
-          bundles.push(normalizeBundle(bundle));
+          const normalized = normalizeBundle(bundle);
+          normalized.downloads = Number(await kv.get(`downloads:${packageName}`)) || 0;
+          bundles.push(normalized);
         }
       }
 
@@ -389,7 +394,9 @@ async function buildServer() {
         });
       }
 
-      return normalizeBundle(bundle);
+      const normalized = normalizeBundle(bundle);
+      normalized.downloads = Number(await kv.get(`downloads:${pkg}`)) || 0;
+      return normalized;
     } catch (error) {
       server.log.error('Error getting bundle:', error);
       return reply.code(500).send({
@@ -887,6 +894,15 @@ async function buildServer() {
         `attachment; filename="${path.basename(filePath)}"`
       );
       reply.header('Content-Length', fileContent.length);
+
+      // Track installs — only count actual app bundles, not raw WASM dev files
+      if (ext === '.mpk' || ext === '.wasm') {
+        const parts = artifactPath.split('/');
+        // Nested path: {package}/{version}/{filename} — extract package name
+        const packageName = parts.length >= 3 ? parts[0] : null;
+        kv.incr('downloads:total').catch(() => {});
+        if (packageName) kv.incr(`downloads:${packageName}`).catch(() => {});
+      }
 
       return reply.send(fileContent);
     } catch (error) {

--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -355,7 +355,8 @@ async function buildServer() {
           }
 
           const normalized = normalizeBundle(bundle);
-          normalized.downloads = Number(await kv.get(`downloads:${packageName}`)) || 0;
+          normalized.downloads =
+            Number(await kv.get(`downloads:${packageName}`)) || 0;
           bundles.push(normalized);
         }
       }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -62,6 +62,7 @@ export const getApps = async (params?: {
       developer_pubkey: author,
       latest_version: bundle.appVersion,
       alias: bundle.metadata?.name,
+      downloads: bundle.downloads || 0,
       developer: {
         display_name: author,
         pubkey: author,
@@ -89,6 +90,7 @@ export const getMyPackages = async (
       developer_pubkey: author,
       latest_version: bundle.appVersion,
       alias: bundle.metadata?.name,
+      downloads: bundle.downloads || 0,
       developer: {
         display_name: author,
         pubkey: author,

--- a/packages/frontend/src/pages/AppsPage.tsx
+++ b/packages/frontend/src/pages/AppsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { Search, Package, ArrowUpRight } from 'lucide-react';
+import { Search, Package, ArrowUpRight, Download } from 'lucide-react';
 import { getApps } from '../lib/api';
 import type { AppSummary } from '../types/api';
 
@@ -126,9 +126,17 @@ function AppCard({ app }: { app: AppSummary }) {
         <span className='text-[11px] text-neutral-400 font-light'>
           {app.developer?.display_name || app.developer_pubkey}
         </span>
-        <span className='text-[11px] text-neutral-600 font-mono'>
-          v{app.latest_version}
-        </span>
+        <div className='flex items-center gap-2'>
+          {app.downloads != null && app.downloads > 0 && (
+            <span className='flex items-center gap-1 text-[11px] text-neutral-500'>
+              <Download className='w-3 h-3' />
+              {app.downloads.toLocaleString()}
+            </span>
+          )}
+          <span className='text-[11px] text-neutral-600 font-mono'>
+            v{app.latest_version}
+          </span>
+        </div>
       </div>
     </Link>
   );

--- a/packages/frontend/src/types/api.ts
+++ b/packages/frontend/src/types/api.ts
@@ -5,6 +5,7 @@ export interface AppSummary {
   developer_pubkey: string;
   latest_version: string;
   alias?: string;
+  downloads?: number;
   developer?: {
     display_name: string;
     website?: string;


### PR DESCRIPTION
#  feat: add download counters app marketplace

## Description
Download (install) counter for every application in the marketplace.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds install tracking and surfaces counts in API responses and UI; risk is mainly around correctness/consistency of Redis counters and additional load on hot endpoints.
> 
> **Overview**
> Adds download/install counters backed by Redis and exposes them through the existing APIs.
> 
> Backend now increments `downloads:total` and `downloads:{package}` when serving `.mpk` artifacts, and includes these counts in `GET /stats` and `GET /api/v2/bundles` responses (with batched reads for listing). The KV wrapper (`kv-client`) gains an `incr` operation with a matching mock implementation.
> 
> Frontend extends `AppSummary` with `downloads`, maps the field from bundle API responses, and displays a download count badge on the Apps marketplace cards when non-zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b7cdfed0b0095ee086ae8c15d991d486b3b22ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->