### PR TITLE
fix: counter

### DIFF
--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -407,6 +407,11 @@ async function buildServer() {
       }
 
       const normalized = normalizeBundle(bundle);
+
+      // Count installs: this endpoint is called exactly once per install click in the desktop app
+      kv.incr('downloads:total').catch(() => {});
+      kv.incr(`downloads:${pkg}`).catch(() => {});
+
       normalized.downloads = Number(await kv.get(`downloads:${pkg}`)) || 0;
       return normalized;
     } catch (error) {
@@ -906,17 +911,6 @@ async function buildServer() {
         `attachment; filename="${path.basename(filePath)}"`
       );
       reply.header('Content-Length', fileContent.length);
-
-      // Track installs — only count actual app bundles (.mpk), not raw WASM dev files
-      if (ext === '.mpk') {
-        const parts = artifactPath.split('/');
-        // Nested path: {package}/{version}/{filename} — extract package name
-        const packageName = parts.length >= 3 ? parts[0] : null;
-        if (packageName) {
-          kv.incr('downloads:total').catch(() => {});
-          kv.incr(`downloads:${packageName}`).catch(() => {});
-        }
-      }
 
       return reply.send(fileContent);
     } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts where download counters are incremented, affecting analytics but not auth or data integrity.
> 
> **Overview**
> Moves download/install tracking from the `/artifacts/*` file-serving route to `GET /api/v2/bundles/:package/:version`, incrementing `downloads:total` and `downloads:<pkg>` when the desktop app triggers an install.
> 
> This stops counting `.mpk` artifact downloads directly and instead counts installs at the bundle metadata endpoint, while still returning the per-package `downloads` value from KV.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f3284345298f2a61939588a2530392580057b05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->