### PR TITLE
fix: cleanup downloads

### DIFF
--- a/packages/frontend/src/pages/AppsPage.tsx
+++ b/packages/frontend/src/pages/AppsPage.tsx
@@ -127,10 +127,10 @@ function AppCard({ app }: { app: AppSummary }) {
           {app.developer?.display_name || app.developer_pubkey}
         </span>
         <div className='flex items-center gap-2'>
-          {app.downloads != null && app.downloads > 0 && (
+          {app.downloads != null && (
             <span className='flex items-center gap-1 text-[11px] text-neutral-500'>
               <Download className='w-3 h-3' />
-              {app.downloads.toLocaleString()}
+              {app.downloads.toLocaleString()} downloads
             </span>
           )}
           <span className='text-[11px] text-neutral-600 font-mono'>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change limited to how the downloads metric is displayed; no data flow or API behavior is modified.
> 
> **Overview**
> Updates `AppsPage` app cards to **always render the downloads metric when `downloads` is non-null**, including `0`, instead of hiding it for zero downloads.
> 
> The displayed value is also clarified by appending the literal "downloads" label after the formatted count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ad49510909b6651958c32e1657efbb1ba1c25c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->