### PR TITLE
Feat download testing v2

### DIFF
--- a/api/lib/kv-client.js
+++ b/api/lib/kv-client.js
@@ -63,6 +63,15 @@ if (isProduction && process.env.REDIS_URL) {
       return await redisClient.del(key);
     },
 
+    /**
+     * Increment key by 1 (atomic). Key created at 0 if missing.
+     * Returns the value after increment (number).
+     */
+    async incr(key) {
+      await this._ensureConnected();
+      return await redisClient.incr(key);
+    },
+
     // Hash operations
     async hSet(key, obj) {
       await this._ensureConnected();
@@ -144,6 +153,13 @@ if (isProduction && process.env.REDIS_URL) {
       const existed = mockStore.has(key);
       mockStore.delete(key);
       return existed ? 1 : 0;
+    },
+
+    async incr(key) {
+      const current = mockStore.get(key);
+      const next = (current != null ? parseInt(current, 10) : 0) + 1;
+      mockStore.set(key, String(next));
+      return next;
     },
 
     // Hash operations

--- a/api/v2/bundles/[package]/[version].js
+++ b/api/v2/bundles/[package]/[version].js
@@ -254,7 +254,9 @@ module.exports = async function handler(req, res) {
     const data = await kv.get(`bundle:${pkg}/${version}`);
     if (!data) return res.status(404).json({ error: 'not_found' });
     const raw = JSON.parse(data).json;
-    const downloadCount = await kv.get(`downloads:${pkg}`);
+    const downloadCount = await kv.get(
+      `downloads:${(pkg || '').toLowerCase()}`
+    );
     const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
     return res.status(200).json({
       ...normalizeBundle(raw),

--- a/api/v2/bundles/[package]/[version].js
+++ b/api/v2/bundles/[package]/[version].js
@@ -254,7 +254,12 @@ module.exports = async function handler(req, res) {
     const data = await kv.get(`bundle:${pkg}/${version}`);
     if (!data) return res.status(404).json({ error: 'not_found' });
     const raw = JSON.parse(data).json;
-    return res.status(200).json(normalizeBundle(raw));
+    const downloadCount = await kv.get(`downloads:${pkg}`);
+    const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
+    return res.status(200).json({
+      ...normalizeBundle(raw),
+      downloads,
+    });
   } catch (error) {
     console.error('Get Error:', error);
     return res.status(500).json({

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -109,7 +109,11 @@ module.exports = async function handler(req, res) {
       const data = await kv.get(`bundle:${pkg}/${version}`);
       if (!data) return res.status(404).json({ error: 'not_found' });
       const raw = JSON.parse(data).json;
-      return res.status(200).json([normalizeBundle(raw)]);
+      const downloadCount = await kv.get(`downloads:${pkg}`);
+      const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
+      return res.status(200).json([
+        { ...normalizeBundle(raw), downloads },
+      ]);
     }
 
     const allPackages = await kv.sMembers('bundles:all');
@@ -127,7 +131,9 @@ module.exports = async function handler(req, res) {
       const bundle = JSON.parse(data).json;
       if (developer && bundle.signature?.pubkey !== developer) continue;
       if (author && bundle.metadata?.author !== author) continue;
-      bundles.push(normalizeBundle(bundle));
+      const downloadCount = await kv.get(`downloads:${packageName}`);
+      const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
+      bundles.push({ ...normalizeBundle(bundle), downloads });
     }
 
     bundles.sort((a, b) => a.package.localeCompare(b.package));

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -109,7 +109,9 @@ module.exports = async function handler(req, res) {
       const data = await kv.get(`bundle:${pkg}/${version}`);
       if (!data) return res.status(404).json({ error: 'not_found' });
       const raw = JSON.parse(data).json;
-      const downloadCount = await kv.get(`downloads:${pkg}`);
+      const downloadCount = await kv.get(
+        `downloads:${(pkg || '').toLowerCase()}`
+      );
       const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
       return res.status(200).json([{ ...normalizeBundle(raw), downloads }]);
     }
@@ -129,7 +131,9 @@ module.exports = async function handler(req, res) {
       const bundle = JSON.parse(data).json;
       if (developer && bundle.signature?.pubkey !== developer) continue;
       if (author && bundle.metadata?.author !== author) continue;
-      const downloadCount = await kv.get(`downloads:${packageName}`);
+      const downloadCount = await kv.get(
+        `downloads:${(packageName || '').toLowerCase()}`
+      );
       const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
       bundles.push({ ...normalizeBundle(bundle), downloads });
     }

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -111,9 +111,7 @@ module.exports = async function handler(req, res) {
       const raw = JSON.parse(data).json;
       const downloadCount = await kv.get(`downloads:${pkg}`);
       const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
-      return res.status(200).json([
-        { ...normalizeBundle(raw), downloads },
-      ]);
+      return res.status(200).json([{ ...normalizeBundle(raw), downloads }]);
     }
 
     const allPackages = await kv.sMembers('bundles:all');

--- a/api/v2/downloads/record.js
+++ b/api/v2/downloads/record.js
@@ -1,0 +1,62 @@
+/**
+ * Record a download (public endpoint).
+ * POST /api/v2/downloads/record
+ * Body: { "package": "com.example.app", "version": "1.0.0" } (version optional)
+ *
+ * Increments Redis: downloads:total, downloads:<package>
+ * No auth; call after a successful artifact download/install.
+ */
+
+const { kv } = require('../../lib/kv-client');
+
+const PACKAGE_REGEX = /^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i;
+
+module.exports = async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  let body;
+  try {
+    body = typeof req.body === 'object' && req.body !== null ? req.body : {};
+  } catch {
+    body = {};
+  }
+
+  const packageName = body.package ?? body.pkg;
+  if (!packageName || typeof packageName !== 'string') {
+    return res.status(400).json({
+      error: 'invalid_request',
+      message: 'Missing or invalid "package" in body',
+    });
+  }
+
+  const pkg = packageName.trim();
+  if (!PACKAGE_REGEX.test(pkg)) {
+    return res.status(400).json({
+      error: 'invalid_request',
+      message: 'Invalid package name format',
+    });
+  }
+
+  try {
+    await kv.incr('downloads:total');
+    await kv.incr(`downloads:${pkg}`);
+    console.log('Download recorded', { package: pkg, version: body.version || null });
+    return res.status(200).json({ ok: true, package: pkg });
+  } catch (error) {
+    console.error('Record download error:', error);
+    return res.status(500).json({
+      error: 'internal_error',
+      message: error?.message ?? String(error),
+    });
+  }
+};

--- a/api/v2/downloads/record.js
+++ b/api/v2/downloads/record.js
@@ -50,7 +50,10 @@ module.exports = async function handler(req, res) {
   try {
     await kv.incr('downloads:total');
     await kv.incr(`downloads:${pkg}`);
-    console.log('Download recorded', { package: pkg, version: body.version || null });
+    console.log('Download recorded', {
+      package: pkg,
+      version: body.version || null,
+    });
     return res.status(200).json({ ok: true, package: pkg });
   } catch (error) {
     console.error('Record download error:', error);

--- a/api/v2/downloads/record.js
+++ b/api/v2/downloads/record.js
@@ -47,14 +47,17 @@ module.exports = async function handler(req, res) {
     });
   }
 
+  // Use lowercase for Redis key so it matches canonical lookups in bundle endpoints
+  const canonicalPkg = pkg.toLowerCase();
+
   try {
     await kv.incr('downloads:total');
-    await kv.incr(`downloads:${pkg}`);
+    await kv.incr(`downloads:${canonicalPkg}`);
     console.log('Download recorded', {
-      package: pkg,
+      package: canonicalPkg,
       version: body.version || null,
     });
-    return res.status(200).json({ ok: true, package: pkg });
+    return res.status(200).json({ ok: true, package: canonicalPkg });
   } catch (error) {
     console.error('Record download error:', error);
     return res.status(500).json({

--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -303,12 +303,14 @@ async function buildServer() {
             message: `Bundle ${pkg}@${version} not found`,
           });
         }
+        const canonicalPkg = pkg.toLowerCase();
         await Promise.all([
           kv.incr('downloads:total').catch(() => {}),
-          kv.incr(`downloads:${pkg}`).catch(() => {}),
+          kv.incr(`downloads:${canonicalPkg}`).catch(() => {}),
         ]);
         const normalized = normalizeBundle(bundle);
-        normalized.downloads = Number(await kv.get(`downloads:${pkg}`)) || 0;
+        normalized.downloads =
+          Number(await kv.get(`downloads:${canonicalPkg}`)) || 0;
         return [normalized];
       }
 
@@ -364,10 +366,10 @@ async function buildServer() {
         }
       }
 
-      // Batch Redis reads for download counts (one per unique package)
+      // Batch Redis reads for download counts (one per unique package; keys are canonical lowercase)
       const uniquePackages = [...new Set(bundles.map(b => b.packageName))];
       const downloadCounts = await Promise.all(
-        uniquePackages.map(p => kv.get(`downloads:${p}`))
+        uniquePackages.map(p => kv.get(`downloads:${p.toLowerCase()}`))
       );
       const countByPackage = Object.fromEntries(
         uniquePackages.map((p, i) => [p, Number(downloadCounts[i]) || 0])
@@ -414,11 +416,13 @@ async function buildServer() {
       const normalized = normalizeBundle(bundle);
 
       // Count installs: this endpoint is called exactly once per install click in the desktop app
+      const canonicalPkg = pkg.toLowerCase();
       await Promise.all([
         kv.incr('downloads:total').catch(() => {}),
-        kv.incr(`downloads:${pkg}`).catch(() => {}),
+        kv.incr(`downloads:${canonicalPkg}`).catch(() => {}),
       ]);
-      normalized.downloads = Number(await kv.get(`downloads:${pkg}`)) || 0;
+      normalized.downloads =
+        Number(await kv.get(`downloads:${canonicalPkg}`)) || 0;
       return normalized;
     } catch (error) {
       server.log.error('Error getting bundle:', error);
@@ -902,10 +906,11 @@ async function buildServer() {
     const pathParts = artifactPath.split('/').filter(Boolean);
     if (pathParts.length >= 2) {
       const pkg = pathParts[0];
+      const canonicalPkg = pkg.toLowerCase();
       try {
         await Promise.all([
           kv.incr('downloads:total'),
-          kv.incr(`downloads:${pkg}`),
+          kv.incr(`downloads:${canonicalPkg}`),
         ]);
         request.log.info(
           { pkg, artifactPath },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new unauthenticated endpoint that mutates Redis counters and changes bundle API responses to include download counts, which could affect metrics integrity and increase Redis load if abused.
> 
> **Overview**
> Adds Redis-backed download counting across the v2 APIs: bundle `GET` responses now include a `downloads` field sourced from `downloads:<package>`.
> 
> Introduces a public `POST /api/v2/downloads/record` endpoint to increment `downloads:total` and per-package counters, and standardizes counting keys to *canonical lowercase* in both the Vercel API routes and the Fastify backend (including artifact download counting).
> 
> Extends the shared `kv-client` wrapper with an atomic `incr` operation (implemented for both real Redis and the in-memory mock).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d76559104699c1b1b9c05aa073e962e84d18f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->