### PR TITLE
feat: add username first logic registry

### DIFF
--- a/api/lib/kv-client.js
+++ b/api/lib/kv-client.js
@@ -63,6 +63,15 @@ if (isProduction && process.env.REDIS_URL) {
       return await redisClient.del(key);
     },
 
+    /**
+     * Increment key by 1 (atomic). Key created at 0 if missing.
+     * Returns the value after increment (number).
+     */
+    async incr(key) {
+      await this._ensureConnected();
+      return await redisClient.incr(key);
+    },
+
     // Hash operations
     async hSet(key, obj) {
       await this._ensureConnected();
@@ -144,6 +153,13 @@ if (isProduction && process.env.REDIS_URL) {
       const existed = mockStore.has(key);
       mockStore.delete(key);
       return existed ? 1 : 0;
+    },
+
+    async incr(key) {
+      const current = mockStore.get(key);
+      const next = (current != null ? parseInt(current, 10) : 0) + 1;
+      mockStore.set(key, String(next));
+      return next;
     },
 
     // Hash operations

--- a/api/v2/bundles/[package]/[version].js
+++ b/api/v2/bundles/[package]/[version].js
@@ -254,7 +254,9 @@ module.exports = async function handler(req, res) {
     const data = await kv.get(`bundle:${pkg}/${version}`);
     if (!data) return res.status(404).json({ error: 'not_found' });
     const raw = JSON.parse(data).json;
-    const downloadCount = await kv.get(`downloads:${pkg}`);
+    const downloadCount = await kv.get(
+      `downloads:${(pkg || '').toLowerCase()}`
+    );
     const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
     return res.status(200).json({
       ...normalizeBundle(raw),

--- a/api/v2/bundles/[package]/[version].js
+++ b/api/v2/bundles/[package]/[version].js
@@ -254,7 +254,12 @@ module.exports = async function handler(req, res) {
     const data = await kv.get(`bundle:${pkg}/${version}`);
     if (!data) return res.status(404).json({ error: 'not_found' });
     const raw = JSON.parse(data).json;
-    return res.status(200).json(normalizeBundle(raw));
+    const downloadCount = await kv.get(`downloads:${pkg}`);
+    const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
+    return res.status(200).json({
+      ...normalizeBundle(raw),
+      downloads,
+    });
   } catch (error) {
     console.error('Get Error:', error);
     return res.status(500).json({

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -109,7 +109,11 @@ module.exports = async function handler(req, res) {
       const data = await kv.get(`bundle:${pkg}/${version}`);
       if (!data) return res.status(404).json({ error: 'not_found' });
       const raw = JSON.parse(data).json;
-      return res.status(200).json([normalizeBundle(raw)]);
+      const downloadCount = await kv.get(`downloads:${pkg}`);
+      const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
+      return res.status(200).json([
+        { ...normalizeBundle(raw), downloads },
+      ]);
     }
 
     const allPackages = await kv.sMembers('bundles:all');
@@ -127,7 +131,9 @@ module.exports = async function handler(req, res) {
       const bundle = JSON.parse(data).json;
       if (developer && bundle.signature?.pubkey !== developer) continue;
       if (author && bundle.metadata?.author !== author) continue;
-      bundles.push(normalizeBundle(bundle));
+      const downloadCount = await kv.get(`downloads:${packageName}`);
+      const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
+      bundles.push({ ...normalizeBundle(bundle), downloads });
     }
 
     bundles.sort((a, b) => a.package.localeCompare(b.package));

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -109,7 +109,9 @@ module.exports = async function handler(req, res) {
       const data = await kv.get(`bundle:${pkg}/${version}`);
       if (!data) return res.status(404).json({ error: 'not_found' });
       const raw = JSON.parse(data).json;
-      const downloadCount = await kv.get(`downloads:${pkg}`);
+      const downloadCount = await kv.get(
+        `downloads:${(pkg || '').toLowerCase()}`
+      );
       const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
       return res.status(200).json([{ ...normalizeBundle(raw), downloads }]);
     }
@@ -129,7 +131,9 @@ module.exports = async function handler(req, res) {
       const bundle = JSON.parse(data).json;
       if (developer && bundle.signature?.pubkey !== developer) continue;
       if (author && bundle.metadata?.author !== author) continue;
-      const downloadCount = await kv.get(`downloads:${packageName}`);
+      const downloadCount = await kv.get(
+        `downloads:${(packageName || '').toLowerCase()}`
+      );
       const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
       bundles.push({ ...normalizeBundle(bundle), downloads });
     }

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -111,9 +111,7 @@ module.exports = async function handler(req, res) {
       const raw = JSON.parse(data).json;
       const downloadCount = await kv.get(`downloads:${pkg}`);
       const downloads = downloadCount ? parseInt(downloadCount, 10) : 0;
-      return res.status(200).json([
-        { ...normalizeBundle(raw), downloads },
-      ]);
+      return res.status(200).json([{ ...normalizeBundle(raw), downloads }]);
     }
 
     const allPackages = await kv.sMembers('bundles:all');

--- a/api/v2/downloads/record.js
+++ b/api/v2/downloads/record.js
@@ -1,0 +1,62 @@
+/**
+ * Record a download (public endpoint).
+ * POST /api/v2/downloads/record
+ * Body: { "package": "com.example.app", "version": "1.0.0" } (version optional)
+ *
+ * Increments Redis: downloads:total, downloads:<package>
+ * No auth; call after a successful artifact download/install.
+ */
+
+const { kv } = require('../../lib/kv-client');
+
+const PACKAGE_REGEX = /^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i;
+
+module.exports = async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  let body;
+  try {
+    body = typeof req.body === 'object' && req.body !== null ? req.body : {};
+  } catch {
+    body = {};
+  }
+
+  const packageName = body.package ?? body.pkg;
+  if (!packageName || typeof packageName !== 'string') {
+    return res.status(400).json({
+      error: 'invalid_request',
+      message: 'Missing or invalid "package" in body',
+    });
+  }
+
+  const pkg = packageName.trim();
+  if (!PACKAGE_REGEX.test(pkg)) {
+    return res.status(400).json({
+      error: 'invalid_request',
+      message: 'Invalid package name format',
+    });
+  }
+
+  try {
+    await kv.incr('downloads:total');
+    await kv.incr(`downloads:${pkg}`);
+    console.log('Download recorded', { package: pkg, version: body.version || null });
+    return res.status(200).json({ ok: true, package: pkg });
+  } catch (error) {
+    console.error('Record download error:', error);
+    return res.status(500).json({
+      error: 'internal_error',
+      message: error?.message ?? String(error),
+    });
+  }
+};

--- a/api/v2/downloads/record.js
+++ b/api/v2/downloads/record.js
@@ -50,7 +50,10 @@ module.exports = async function handler(req, res) {
   try {
     await kv.incr('downloads:total');
     await kv.incr(`downloads:${pkg}`);
-    console.log('Download recorded', { package: pkg, version: body.version || null });
+    console.log('Download recorded', {
+      package: pkg,
+      version: body.version || null,
+    });
     return res.status(200).json({ ok: true, package: pkg });
   } catch (error) {
     console.error('Record download error:', error);

--- a/api/v2/downloads/record.js
+++ b/api/v2/downloads/record.js
@@ -47,14 +47,17 @@ module.exports = async function handler(req, res) {
     });
   }
 
+  // Use lowercase for Redis key so it matches canonical lookups in bundle endpoints
+  const canonicalPkg = pkg.toLowerCase();
+
   try {
     await kv.incr('downloads:total');
-    await kv.incr(`downloads:${pkg}`);
+    await kv.incr(`downloads:${canonicalPkg}`);
     console.log('Download recorded', {
-      package: pkg,
+      package: canonicalPkg,
       version: body.version || null,
     });
-    return res.status(200).json({ ok: true, package: pkg });
+    return res.status(200).json({ ok: true, package: canonicalPkg });
   } catch (error) {
     console.error('Record download error:', error);
     return res.status(500).json({

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,7 +17,8 @@
     "docker:build": "docker build -f packages/backend/Dockerfile -t calimero-registry-backend .",
     "docker:run": "docker run -p 8080:8080 calimero-registry-backend",
     "docker:compose": "docker-compose up -d",
-    "docker:compose:dev": "docker-compose --profile dev up -d"
+    "docker:compose:dev": "docker-compose --profile dev up -d",
+    "clear-registry": "node scripts/clear-registry.js"
   },
   "dependencies": {
     "@fastify/cookie": "^9.3.1",

--- a/packages/backend/scripts/clear-registry.js
+++ b/packages/backend/scripts/clear-registry.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * clear-registry.js
+ * Wipes ALL keys from the Redis database (bundles, users, orgs, tokens, download counts).
+ * Reads REDIS_URL from .env in the backend package directory.
+ *
+ * Usage:
+ *   node scripts/clear-registry.js
+ *   node scripts/clear-registry.js --yes    # skip confirmation prompt
+ */
+
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+
+const { createClient } = require('redis');
+const readline = require('readline');
+
+const REDIS_URL = process.env.REDIS_URL;
+if (!REDIS_URL) {
+  console.error('ERROR: REDIS_URL not set. Check your .env file.');
+  process.exit(1);
+}
+
+async function confirm() {
+  if (process.argv.includes('--yes')) return true;
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise(resolve => {
+    rl.question(
+      '\n⚠️  This will permanently delete ALL data in Redis (bundles, users, orgs, tokens, everything).\nType "yes" to continue: ',
+      answer => {
+        rl.close();
+        resolve(answer.trim().toLowerCase() === 'yes');
+      }
+    );
+  });
+}
+
+async function main() {
+  const ok = await confirm();
+  if (!ok) {
+    console.log('Aborted.');
+    process.exit(0);
+  }
+
+  const client = createClient({ url: REDIS_URL });
+  client.on('error', err => console.error('Redis error:', err));
+
+  console.log('\nConnecting to Redis...');
+  await client.connect();
+  console.log('Connected.');
+
+  // FLUSHDB wipes only the currently selected database (db 0 by default)
+  await client.flushDb();
+
+  console.log('✅ Database cleared. All keys deleted.\n');
+  await client.quit();
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/backend/src/lib/user-storage.js
+++ b/packages/backend/src/lib/user-storage.js
@@ -1,0 +1,203 @@
+/**
+ * User profile storage (Redis).
+ * Keys:
+ *   user:{userId}          → JSON { id, email, username, verified, name, picture, createdAt }
+ *   username:{username}    → userId  (uniqueness index)
+ *   email2user:{email}     → userId  (reverse lookup)
+ */
+
+const { kv } = require('./kv-client');
+
+const USER_PREFIX = 'user:';
+const USERNAME_PREFIX = 'username:';
+const EMAIL2USER_PREFIX = 'email2user:';
+
+// 2-50 chars: starts & ends with letter or number, may contain _ or - in between
+const USERNAME_REGEX = /^[a-z0-9]([a-z0-9_-]{0,48}[a-z0-9])?$/;
+
+// Reserved names and common profanity — exact-match or substring check
+const BLOCKED_TERMS = new Set([
+  // Profanity
+  'fuck',
+  'shit',
+  'ass',
+  'bitch',
+  'bastard',
+  'cunt',
+  'dick',
+  'pussy',
+  'cock',
+  'nigger',
+  'nigga',
+  'faggot',
+  'fag',
+  'whore',
+  'slut',
+  'retard',
+  'rape',
+  'piss',
+  'prick',
+  'twat',
+  'wanker',
+  'asshole',
+  'arsehole',
+  'bullshit',
+  // Hate / extremist
+  'nazi',
+  'hitler',
+  // Reserved system names
+  'admin',
+  'administrator',
+  'root',
+  'system',
+  'support',
+  'moderator',
+  'calimero',
+  'calimeronetwork',
+]);
+
+function containsBlockedTerm(username) {
+  const lower = username.toLowerCase().replace(/[-_]/g, '');
+  for (const term of BLOCKED_TERMS) {
+    if (lower.includes(term)) return true;
+  }
+  return false;
+}
+
+/**
+ * Get or create a user profile from a Google OAuth payload.
+ * Preserves username if already set. Updates name/picture/verified on every login.
+ * @param {{ id: string, email: string, name: string, picture: string|null }} googleUser
+ * @returns {Promise<object>} full user profile
+ */
+async function getOrCreateUser(googleUser) {
+  const { id, email, name, picture } = googleUser;
+  const emailNorm = (email || '').toLowerCase();
+  const verified = emailNorm.endsWith('@calimero.network');
+
+  const rawUserId = await kv.get(EMAIL2USER_PREFIX + emailNorm);
+  if (rawUserId) {
+    const userId =
+      typeof rawUserId === 'string' ? rawUserId : String(rawUserId);
+    const raw = await kv.get(USER_PREFIX + userId);
+    if (raw) {
+      const existing = JSON.parse(typeof raw === 'string' ? raw : String(raw));
+      const updated = {
+        ...existing,
+        name: name || existing.name,
+        picture: picture || existing.picture,
+        verified,
+      };
+      await kv.set(USER_PREFIX + userId, JSON.stringify(updated));
+      return updated;
+    }
+  }
+
+  const user = {
+    id,
+    email: emailNorm,
+    name: name || emailNorm,
+    picture: picture || null,
+    username: null,
+    verified,
+    createdAt: new Date().toISOString(),
+  };
+  await kv.set(USER_PREFIX + id, JSON.stringify(user));
+  await kv.set(EMAIL2USER_PREFIX + emailNorm, id);
+  return user;
+}
+
+/**
+ * @param {string} email
+ * @returns {Promise<object|null>}
+ */
+async function getUserByEmail(email) {
+  if (!email) return null;
+  const norm = email.toLowerCase();
+  const rawId = await kv.get(EMAIL2USER_PREFIX + norm);
+  if (!rawId) return null;
+  return getUserById(typeof rawId === 'string' ? rawId : String(rawId));
+}
+
+/**
+ * @param {string} userId
+ * @returns {Promise<object|null>}
+ */
+async function getUserById(userId) {
+  if (!userId) return null;
+  const raw = await kv.get(USER_PREFIX + String(userId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(typeof raw === 'string' ? raw : String(raw));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} username
+ * @returns {Promise<object|null>}
+ */
+async function getUserByUsername(username) {
+  if (!username) return null;
+  const norm = username.toLowerCase();
+  const rawId = await kv.get(USERNAME_PREFIX + norm);
+  if (!rawId) return null;
+  return getUserById(typeof rawId === 'string' ? rawId : String(rawId));
+}
+
+/**
+ * Claim a username for an existing user. Can only be done once.
+ * @param {string} userId
+ * @param {string} username
+ * @returns {Promise<object>} updated user profile
+ * @throws {{ message: string, code: string }}
+ */
+async function claimUsername(userId, username) {
+  const norm = username.toLowerCase();
+  if (!USERNAME_REGEX.test(norm)) {
+    const err = new Error(
+      'Username must be 2–50 characters, use only letters, numbers, underscores, or hyphens, and start and end with a letter or number'
+    );
+    err.code = 'invalid_format';
+    throw err;
+  }
+  if (containsBlockedTerm(norm)) {
+    const err = new Error('This username is not allowed');
+    err.code = 'blocked';
+    throw err;
+  }
+  const existingOwner = await kv.get(USERNAME_PREFIX + norm);
+  if (existingOwner && String(existingOwner) !== String(userId)) {
+    const err = new Error('This username is already taken');
+    err.code = 'taken';
+    throw err;
+  }
+  const raw = await kv.get(USER_PREFIX + String(userId));
+  if (!raw) {
+    const err = new Error('User not found');
+    err.code = 'not_found';
+    throw err;
+  }
+  const user = JSON.parse(typeof raw === 'string' ? raw : String(raw));
+  if (user.username) {
+    const err = new Error(
+      'Username has already been set and cannot be changed'
+    );
+    err.code = 'immutable';
+    throw err;
+  }
+  user.username = norm;
+  await kv.set(USER_PREFIX + String(userId), JSON.stringify(user));
+  await kv.set(USERNAME_PREFIX + norm, String(userId));
+  return user;
+}
+
+module.exports = {
+  getOrCreateUser,
+  getUserByEmail,
+  getUserById,
+  getUserByUsername,
+  claimUsername,
+  USERNAME_REGEX,
+};

--- a/packages/backend/src/routes/auth-routes.js
+++ b/packages/backend/src/routes/auth-routes.js
@@ -10,6 +10,12 @@ const {
   listApiTokens,
   revokeApiToken,
 } = require('../lib/auth');
+const {
+  getOrCreateUser,
+  getUserById,
+  getUserByEmail,
+  claimUsername,
+} = require('../lib/user-storage');
 
 const STATE_COOKIE_NAME = 'oauth_state';
 const STATE_MAX_AGE = 600; // 10 minutes
@@ -118,6 +124,9 @@ async function authRoutes(server, options) {
       return reply.redirect(302, `${frontendUrl}?error=oauth_failed`);
     }
 
+    // Create or update user profile in Redis (username/verified persistence)
+    await getOrCreateUser(user);
+
     const token = await createSessionToken(
       user,
       sessionSecret,
@@ -143,14 +152,85 @@ async function authRoutes(server, options) {
         .code(401)
         .send({ error: 'unauthorized', message: 'Not signed in' });
     }
+    // Enrich with username and verified from Redis profile
+    const profile =
+      (await getUserById(user.id)) || (await getUserByEmail(user.email));
+    const username = profile?.username ?? null;
+    const verified =
+      profile?.verified ?? (user.email || '').endsWith('@calimero.network');
     return {
       user: {
         id: user.id,
         email: user.email,
         name: user.name,
         picture: user.picture,
+        username,
+        verified,
       },
     };
+  });
+
+  // POST /api/auth/username — claim a username (immutable once set)
+  server.post('/api/auth/username', async (request, reply) => {
+    const user = await resolveUser(request);
+    if (!user) {
+      return reply
+        .code(401)
+        .send({ error: 'unauthorized', message: 'Login required' });
+    }
+    const { username } = request.body || {};
+    if (!username || typeof username !== 'string') {
+      return reply
+        .code(400)
+        .send({ error: 'bad_request', message: 'username is required' });
+    }
+    try {
+      const updated = await claimUsername(user.id, username.trim());
+      return reply.code(200).send({ username: updated.username });
+    } catch (err) {
+      const code = err.code;
+      if (code === 'invalid_format')
+        return reply
+          .code(400)
+          .send({ error: 'invalid_format', message: err.message });
+      if (code === 'blocked')
+        return reply.code(400).send({ error: 'blocked', message: err.message });
+      if (code === 'taken')
+        return reply.code(409).send({ error: 'taken', message: err.message });
+      if (code === 'immutable')
+        return reply
+          .code(409)
+          .send({ error: 'immutable', message: err.message });
+      server.log.error({ err }, 'POST /api/auth/username failed');
+      return reply
+        .code(500)
+        .send({ error: 'server_error', message: 'Failed to set username' });
+    }
+  });
+
+  // GET /api/users/resolve?emails=e1,e2,e3 — batch resolve emails to { username, verified }
+  // Returns: { [email]: { username: string|null, verified: boolean } }
+  server.get('/api/users/resolve', async (request, reply) => {
+    const raw = request.query?.emails;
+    if (!raw || typeof raw !== 'string') {
+      return reply.send({});
+    }
+    const emails = raw
+      .split(',')
+      .map(e => e.trim().toLowerCase())
+      .filter(Boolean)
+      .slice(0, 50);
+    const result = {};
+    await Promise.all(
+      emails.map(async email => {
+        const profile = await getUserByEmail(email);
+        result[email] = {
+          username: profile?.username ?? null,
+          verified: profile?.verified ?? email.endsWith('@calimero.network'),
+        };
+      })
+    );
+    return reply.send(result);
   });
 
   // POST /api/auth/logout — clear session cookie

--- a/packages/backend/src/routes/org-routes.js
+++ b/packages/backend/src/routes/org-routes.js
@@ -23,6 +23,7 @@ const {
   deleteOrg,
 } = require('../lib/org-storage');
 const { verifySessionToken, verifyApiToken } = require('../lib/auth');
+const { getUserByEmail } = require('../lib/user-storage');
 const { BundleStorageKV } = require('../lib/bundle-storage-kv');
 const config = require('../config');
 
@@ -453,7 +454,7 @@ async function orgRoutes(server) {
     return reply.send({ packages });
   });
 
-  // GET /api/v2/orgs/:orgId/members — list members (email + role, public)
+  // GET /api/v2/orgs/:orgId/members — list members (username + role, public; emails not exposed)
   server.get('/api/v2/orgs/:orgId/members', async (request, reply) => {
     const { orgId } = request.params;
     const org = await getOrg(orgId);
@@ -464,14 +465,19 @@ async function orgRoutes(server) {
       });
     }
     const emails = await getOrgMembers(orgId);
-    const roles = {};
-    for (const email of emails) {
-      const role = await getOrgMemberRole(orgId, email);
-      roles[email] = role || 'member';
-    }
-    return reply.send({
-      members: emails.map(email => ({ email, role: roles[email] })),
-    });
+    const members = await Promise.all(
+      emails.map(async email => {
+        const role = await getOrgMemberRole(orgId, email);
+        const profile = await getUserByEmail(email);
+        return {
+          email, // kept for internal auth checks (not displayed in UI)
+          username: profile?.username ?? null,
+          verified: profile?.verified ?? email.endsWith('@calimero.network'),
+          role: role || 'member',
+        };
+      })
+    );
+    return reply.send({ members });
   });
 }
 

--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -303,12 +303,14 @@ async function buildServer() {
             message: `Bundle ${pkg}@${version} not found`,
           });
         }
+        const canonicalPkg = pkg.toLowerCase();
         await Promise.all([
           kv.incr('downloads:total').catch(() => {}),
-          kv.incr(`downloads:${pkg}`).catch(() => {}),
+          kv.incr(`downloads:${canonicalPkg}`).catch(() => {}),
         ]);
         const normalized = normalizeBundle(bundle);
-        normalized.downloads = Number(await kv.get(`downloads:${pkg}`)) || 0;
+        normalized.downloads =
+          Number(await kv.get(`downloads:${canonicalPkg}`)) || 0;
         return [normalized];
       }
 
@@ -364,10 +366,10 @@ async function buildServer() {
         }
       }
 
-      // Batch Redis reads for download counts (one per unique package)
+      // Batch Redis reads for download counts (one per unique package; keys are canonical lowercase)
       const uniquePackages = [...new Set(bundles.map(b => b.packageName))];
       const downloadCounts = await Promise.all(
-        uniquePackages.map(p => kv.get(`downloads:${p}`))
+        uniquePackages.map(p => kv.get(`downloads:${p.toLowerCase()}`))
       );
       const countByPackage = Object.fromEntries(
         uniquePackages.map((p, i) => [p, Number(downloadCounts[i]) || 0])
@@ -414,11 +416,13 @@ async function buildServer() {
       const normalized = normalizeBundle(bundle);
 
       // Count installs: this endpoint is called exactly once per install click in the desktop app
+      const canonicalPkg = pkg.toLowerCase();
       await Promise.all([
         kv.incr('downloads:total').catch(() => {}),
-        kv.incr(`downloads:${pkg}`).catch(() => {}),
+        kv.incr(`downloads:${canonicalPkg}`).catch(() => {}),
       ]);
-      normalized.downloads = Number(await kv.get(`downloads:${pkg}`)) || 0;
+      normalized.downloads =
+        Number(await kv.get(`downloads:${canonicalPkg}`)) || 0;
       return normalized;
     } catch (error) {
       server.log.error('Error getting bundle:', error);
@@ -902,10 +906,11 @@ async function buildServer() {
     const pathParts = artifactPath.split('/').filter(Boolean);
     if (pathParts.length >= 2) {
       const pkg = pathParts[0];
+      const canonicalPkg = pkg.toLowerCase();
       try {
         await Promise.all([
           kv.incr('downloads:total'),
-          kv.incr(`downloads:${pkg}`),
+          kv.incr(`downloads:${canonicalPkg}`),
         ]);
         request.log.info(
           { pkg, artifactPath },

--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -26,7 +26,8 @@ const {
   getPkg2Org,
   getOrgMemberRole,
 } = require('./lib/org-storage');
-const { verifySessionToken } = require('./lib/auth');
+const { verifySessionToken, verifyApiToken } = require('./lib/auth');
+const { getUserByEmail } = require('./lib/user-storage');
 
 async function buildServer() {
   const server = fastify({
@@ -353,10 +354,11 @@ async function buildServer() {
             }
           }
 
-          // Filter by metadata.author (e.g. for "My packages" by email)
+          // Filter by metadata._ownerEmail (preferred) or metadata.author (legacy) — used by "My packages"
           if (author) {
-            const bundleAuthor = bundle.metadata?.author;
-            if (!bundleAuthor || bundleAuthor !== author) {
+            const ownerEmail =
+              bundle.metadata?._ownerEmail ?? bundle.metadata?.author;
+            if (!ownerEmail || ownerEmail !== author) {
               continue;
             }
           }
@@ -502,7 +504,8 @@ async function buildServer() {
       if (orgId && sessionUser?.email) {
         const role = await getOrgMemberRole(orgId, sessionUser.email);
         if (role === 'member') {
-          const versionAuthor = existing.metadata?.author;
+          const versionAuthor =
+            existing.metadata?._ownerEmail ?? existing.metadata?.author;
           if (versionAuthor !== sessionUser.email) {
             return reply.code(403).send({
               error: 'forbidden',
@@ -557,6 +560,37 @@ async function buildServer() {
     }
   }
 
+  /**
+   * Resolve the current user from session cookie or Bearer token.
+   * Returns { email, name, username } or null.
+   */
+  async function resolveAuthUser(request) {
+    // Try session cookie first
+    const sessionUser = await getSessionUser(request);
+    if (sessionUser?.email) {
+      const profile = await getUserByEmail(sessionUser.email);
+      return {
+        email: sessionUser.email,
+        name: sessionUser.name,
+        username: profile?.username ?? null,
+      };
+    }
+    // Try Bearer token
+    const auth = request.headers?.['authorization'];
+    if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
+      const tokenData = await verifyApiToken(auth.slice(7));
+      if (tokenData?.email) {
+        const profile = await getUserByEmail(tokenData.email);
+        return {
+          email: tokenData.email,
+          name: tokenData.name,
+          username: profile?.username ?? null,
+        };
+      }
+    }
+    return null;
+  }
+
   // DELETE /api/v2/bundles/:package/:version - Delete a specific version
   server.delete('/api/v2/bundles/:package/:version', async (request, reply) => {
     try {
@@ -578,8 +612,9 @@ async function buildServer() {
         });
       }
 
-      const author = existing.metadata?.author;
-      if (!author || author !== user.email) {
+      const ownerEmail =
+        existing.metadata?._ownerEmail ?? existing.metadata?.author;
+      if (!ownerEmail || ownerEmail !== user.email) {
         return reply.code(403).send({
           error: 'not_owner',
           message: 'Only the package author can delete this version.',
@@ -620,8 +655,9 @@ async function buildServer() {
 
       // Check ownership from the latest version
       const latest = await bundleStorage.getBundleManifest(pkg, versions[0]);
-      const author = latest?.metadata?.author;
-      if (!author || author !== user.email) {
+      const ownerEmail =
+        latest?.metadata?._ownerEmail ?? latest?.metadata?.author;
+      if (!ownerEmail || ownerEmail !== user.email) {
         return reply.code(403).send({
           error: 'not_owner',
           message: 'Only the package author can delete this package.',
@@ -640,7 +676,7 @@ async function buildServer() {
   });
 
   // Shared: validate manifest, verify signature, check ownership, store. Returns { package, appVersion } or throws { statusCode, body }.
-  async function processPushBody(bundleManifest, { userEmail } = {}) {
+  async function processPushBody(bundleManifest, { userEmail, username } = {}) {
     if (
       !bundleManifest ||
       bundleManifest === null ||
@@ -695,7 +731,9 @@ async function buildServer() {
     );
     // Set or preserve author: only set from session when creating a new package; never overwrite on new version.
     // Author is locked from the oldest (first) version, not the latest.
+    // We store: metadata.author = username (display), metadata._ownerEmail = email (ownership checks).
     bundleManifest.metadata = bundleManifest.metadata || {};
+    const displayAuthor = username || userEmail; // prefer username, fall back to email
     if (versions.length > 0) {
       const oldestVersion = versions[versions.length - 1];
       const latestVersion = versions[0];
@@ -706,8 +744,14 @@ async function buildServer() {
       const existingAuthor = manifestOldest?.metadata?.author;
       if (existingAuthor) {
         bundleManifest.metadata.author = existingAuthor;
-      } else if (userEmail) {
-        bundleManifest.metadata.author = userEmail;
+        // Preserve _ownerEmail from oldest manifest if present
+        if (manifestOldest?.metadata?._ownerEmail) {
+          bundleManifest.metadata._ownerEmail =
+            manifestOldest.metadata._ownerEmail;
+        }
+      } else if (displayAuthor) {
+        bundleManifest.metadata.author = displayAuthor;
+        if (userEmail) bundleManifest.metadata._ownerEmail = userEmail;
       }
       const manifestLatest = await bundleStorage.getBundleManifest(
         bundleManifest.package,
@@ -745,8 +789,9 @@ async function buildServer() {
           },
         };
       }
-    } else if (userEmail) {
-      bundleManifest.metadata.author = userEmail;
+    } else if (displayAuthor) {
+      bundleManifest.metadata.author = displayAuthor;
+      if (userEmail) bundleManifest.metadata._ownerEmail = userEmail;
     }
     const overwrite =
       process.env.ALLOW_BUNDLE_OVERWRITE === 'true' ||
@@ -774,7 +819,11 @@ async function buildServer() {
   // POST /api/v2/bundles/push - Push a new bundle (used by CLI)
   const pushBundleHandler = async (request, reply) => {
     try {
-      const result = await processPushBody(request.body);
+      const authUser = await resolveAuthUser(request);
+      const result = await processPushBody(request.body, {
+        userEmail: authUser?.email,
+        username: authUser?.username,
+      });
       return reply.code(201).send({
         message: 'Bundle published successfully',
         package: result.package,
@@ -842,15 +891,11 @@ async function buildServer() {
         _overwrite: true,
       };
 
-      const cookieName = config.auth?.cookieName || 'app_registry_session';
-      const sessionSecret = config.auth?.sessionSecret;
-      const token = request.cookies?.[cookieName];
-      const user =
-        sessionSecret && token
-          ? await verifySessionToken(token, sessionSecret)
-          : null;
-
-      const result = await processPushBody(body, { userEmail: user?.email });
+      const authUser = await resolveAuthUser(request);
+      const result = await processPushBody(body, {
+        userEmail: authUser?.email,
+        username: authUser?.username,
+      });
       return reply.code(201).send({
         message: 'Bundle published successfully',
         package: result.package,

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { UsernameSetupModal } from './components/UsernameSetupModal';
+import { useAuth } from './contexts/AuthContext';
 import HomePage from './pages/HomePage';
 import AppsPage from './pages/AppsPage';
 import AppDetailPage from './pages/AppDetailPage';
@@ -16,41 +18,47 @@ import EditPackagePage from './pages/EditPackagePage';
 import DocsPage from './pages/DocsPage';
 
 function App() {
+  const { user, loading } = useAuth();
+  const needsUsername = !loading && !!user && !user.username;
+
   return (
-    <Layout>
-      <Routes>
-        <Route path='/' element={<HomePage />} />
-        <Route path='/apps' element={<AppsPage />} />
-        <Route path='/apps/:appId' element={<AppDetailPage />} />
-        <Route
-          path='/apps/:appId/:version/edit'
-          element={<EditPackagePage />}
-        />
-        <Route path='/developers' element={<DevelopersPage />} />
-        <Route path='/developers/:pubkey' element={<DeveloperDetailPage />} />
-        <Route path='/upload' element={<UploadPage />} />
-        <Route path='/login' element={<LoginPage />} />
-        <Route
-          path='/my-packages'
-          element={
-            <ProtectedRoute>
-              <MyPackagesPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path='/orgs'
-          element={
-            <ProtectedRoute>
-              <MyOrgsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route path='/orgs/:orgId' element={<OrgDetailPage />} />
-        <Route path='/docs' element={<DocsPage />} />
-        <Route path='*' element={<NotFoundPage />} />
-      </Routes>
-    </Layout>
+    <>
+      {needsUsername && <UsernameSetupModal />}
+      <Layout>
+        <Routes>
+          <Route path='/' element={<HomePage />} />
+          <Route path='/apps' element={<AppsPage />} />
+          <Route path='/apps/:appId' element={<AppDetailPage />} />
+          <Route
+            path='/apps/:appId/:version/edit'
+            element={<EditPackagePage />}
+          />
+          <Route path='/developers' element={<DevelopersPage />} />
+          <Route path='/developers/:pubkey' element={<DeveloperDetailPage />} />
+          <Route path='/upload' element={<UploadPage />} />
+          <Route path='/login' element={<LoginPage />} />
+          <Route
+            path='/my-packages'
+            element={
+              <ProtectedRoute>
+                <MyPackagesPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path='/orgs'
+            element={
+              <ProtectedRoute>
+                <MyOrgsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path='/orgs/:orgId' element={<OrgDetailPage />} />
+          <Route path='/docs' element={<DocsPage />} />
+          <Route path='*' element={<NotFoundPage />} />
+        </Routes>
+      </Layout>
+    </>
   );
 }
 

--- a/packages/frontend/src/components/ProfileDropdown.tsx
+++ b/packages/frontend/src/components/ProfileDropdown.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Box, Building2, LogOut } from 'lucide-react';
+import { Box, Building2, LogOut, BadgeCheck } from 'lucide-react';
 import type { AuthUser } from '@/contexts/AuthContext';
 
 interface ProfileDropdownProps {
@@ -62,7 +62,9 @@ export function ProfileDropdown({
     );
   }
 
-  const displayName = user.email ?? user.name ?? 'Signed in';
+  const displayName = user.username
+    ? `@${user.username}`
+    : (user.name ?? user.email ?? 'Signed in');
   const initials = getInitials(user.name, user.email);
   const initialsAvatar = (
     <div className='flex h-7 w-7 items-center justify-center rounded-full bg-brand-600/80 ring-1 ring-brand-500/60 select-none'>
@@ -89,6 +91,9 @@ export function ProfileDropdown({
         <div className='flex items-center gap-2 px-3 py-2 text-[13px] text-neutral-400'>
           {avatar}
           <span className='truncate text-neutral-300'>{displayName}</span>
+          {user.verified && (
+            <BadgeCheck className='h-3.5 w-3.5 flex-shrink-0 text-emerald-400' />
+          )}
         </div>
         <Link
           to='/my-packages'
@@ -155,8 +160,11 @@ export function ProfileDropdown({
             <p className='truncate text-[12px] text-neutral-400'>
               Signed in as
             </p>
-            <p className='truncate text-[13px] font-medium text-neutral-200'>
+            <p className='flex items-center gap-1.5 truncate text-[13px] font-medium text-neutral-200'>
               {displayName}
+              {user.verified && (
+                <BadgeCheck className='h-3.5 w-3.5 flex-shrink-0 text-emerald-400' />
+              )}
             </p>
           </div>
           <Link

--- a/packages/frontend/src/components/UsernameSetupModal.tsx
+++ b/packages/frontend/src/components/UsernameSetupModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+
+const USERNAME_REGEX = /^[a-z0-9]([a-z0-9_-]{0,48}[a-z0-9])?$/;
+
+function validate(value: string): string | null {
+  if (!value) return 'Username is required';
+  if (value.length < 2) return 'Must be at least 2 characters';
+  if (value.length > 50) return 'Must be 50 characters or fewer';
+  if (!USERNAME_REGEX.test(value))
+    return 'Only lowercase letters, numbers, underscores, and hyphens. Must start and end with a letter or number.';
+  return null;
+}
+
+export function UsernameSetupModal() {
+  const { claimUsername } = useAuth();
+  const [value, setValue] = useState('');
+  const [touched, setTouched] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const validationError = touched ? validate(value) : null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setTouched(true);
+    const err = validate(value);
+    if (err) return;
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      await claimUsername(value.trim());
+    } catch (error: unknown) {
+      const msg =
+        (error as { response?: { data?: { message?: string } } })?.response
+          ?.data?.message || 'Failed to set username. Please try again.';
+      setServerError(msg);
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm'>
+      <div className='w-full max-w-md rounded-xl border border-neutral-700 bg-neutral-900 p-6 shadow-2xl'>
+        <h2 className='text-lg font-semibold text-neutral-100 mb-1'>
+          Choose your username
+        </h2>
+        <p className='text-[13px] text-neutral-400 mb-5'>
+          Pick a username to represent you on the registry. This cannot be
+          changed later.
+        </p>
+
+        <form onSubmit={handleSubmit} className='space-y-4'>
+          <div>
+            <label className='block text-[12px] text-neutral-400 mb-1.5'>
+              Username
+            </label>
+            <div className='relative'>
+              <span className='absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500 text-[13px] select-none'>
+                @
+              </span>
+              <input
+                type='text'
+                value={value}
+                onChange={e => {
+                  setValue(
+                    e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, '')
+                  );
+                  setServerError(null);
+                  if (touched) setTouched(true);
+                }}
+                onBlur={() => setTouched(true)}
+                placeholder='yourname'
+                maxLength={50}
+                autoFocus
+                autoComplete='off'
+                spellCheck={false}
+                className={`input pl-7 w-full font-mono ${
+                  validationError || serverError
+                    ? 'border-red-500/70 focus-visible:ring-red-500/30 focus-visible:border-red-500'
+                    : ''
+                }`}
+              />
+            </div>
+            {(validationError || serverError) && (
+              <p className='mt-1.5 text-[12px] text-red-400'>
+                {validationError || serverError}
+              </p>
+            )}
+            <p className='mt-1.5 text-[11px] text-neutral-600'>
+              2–50 characters. Letters, numbers, underscores, hyphens. Cannot be
+              changed.
+            </p>
+          </div>
+
+          <button
+            type='submit'
+            disabled={submitting}
+            className='w-full rounded-lg bg-brand-600 hover:bg-brand-500 disabled:opacity-50 disabled:cursor-not-allowed text-neutral-900 px-4 py-2.5 text-[13px] font-medium transition-colors'
+          >
+            {submitting ? 'Saving…' : 'Set username'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/contexts/AuthContext.tsx
+++ b/packages/frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,8 @@ export interface AuthUser {
   email: string | null;
   name: string | null;
   picture: string | null;
+  username: string | null;
+  verified: boolean;
 }
 
 interface AuthContextValue {
@@ -21,6 +23,7 @@ interface AuthContextValue {
   login: () => void;
   logout: () => Promise<void>;
   refetchUser: () => Promise<void>;
+  claimUsername: (username: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -69,12 +72,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   }, []);
 
+  const claimUsername = useCallback(
+    async (username: string) => {
+      await api.post('/auth/username', { username });
+      await refetchUser();
+    },
+    [refetchUser]
+  );
+
   const value: AuthContextValue = {
     user,
     loading,
     login,
     logout,
     refetchUser,
+    claimUsername,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -55,6 +55,11 @@ export const getApps = async (params?: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return bundles.map((bundle: any) => {
     const author = bundle.metadata?.author || 'Unknown';
+    const ownerEmail: string =
+      bundle.metadata?._ownerEmail || bundle.metadata?.author || '';
+    const verified =
+      ownerEmail.includes('@') &&
+      ownerEmail.toLowerCase().endsWith('@calimero.network');
     return {
       id: bundle.package,
       name: bundle.metadata?.name || bundle.package,
@@ -63,9 +68,11 @@ export const getApps = async (params?: {
       latest_version: bundle.appVersion,
       alias: bundle.metadata?.name,
       downloads: bundle.downloads || 0,
+      verified,
       developer: {
         display_name: author,
         pubkey: author,
+        verified,
       },
     };
   });
@@ -83,6 +90,11 @@ export const getMyPackages = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return bundles.map((bundle: any) => {
     const author = bundle.metadata?.author || 'Unknown';
+    const ownerEmail: string =
+      bundle.metadata?._ownerEmail || bundle.metadata?.author || '';
+    const verified =
+      ownerEmail.includes('@') &&
+      ownerEmail.toLowerCase().endsWith('@calimero.network');
     return {
       id: bundle.package,
       name: bundle.metadata?.name || bundle.package,
@@ -91,9 +103,11 @@ export const getMyPackages = async (
       latest_version: bundle.appVersion,
       alias: bundle.metadata?.name,
       downloads: bundle.downloads || 0,
+      verified,
       developer: {
         display_name: author,
         pubkey: author,
+        verified,
       },
     };
   });
@@ -385,4 +399,27 @@ export const listApiTokens = async (): Promise<ApiToken[]> => {
 /** Revoke an API token by its tokenId (first 8 chars). */
 export const revokeApiToken = async (tokenId: string): Promise<void> => {
   await api.delete(`/auth/token/${encodeURIComponent(tokenId)}`);
+};
+
+/** Claim a username for the currently logged-in user. Can only be done once. */
+export const claimUsername = async (
+  username: string
+): Promise<{ username: string }> => {
+  const response = await api.post<{ username: string }>('/auth/username', {
+    username,
+  });
+  return response.data;
+};
+
+/** Batch-resolve emails to { username, verified }. Returns a map keyed by email. */
+export const resolveUsers = async (
+  emails: string[]
+): Promise<Record<string, { username: string | null; verified: boolean }>> => {
+  if (!emails.length) return {};
+  const response = await api.get<
+    Record<string, { username: string | null; verified: boolean }>
+  >('/users/resolve', {
+    params: { emails: emails.join(',') },
+  });
+  return response.data ?? {};
 };

--- a/packages/frontend/src/pages/AppDetailPage.tsx
+++ b/packages/frontend/src/pages/AppDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   Trash2,
   Building2,
   ArrowRight,
+  BadgeCheck,
 } from 'lucide-react';
 import {
   api,
@@ -36,6 +37,7 @@ interface V2Bundle {
     name?: string;
     description?: string;
     author?: string;
+    _ownerEmail?: string;
     icon?: string;
     tags?: string[];
     license?: string;
@@ -162,7 +164,11 @@ export default function AppDetailPage() {
   const abi = bundle.abi;
   const sig = bundle.signature;
   const ifaces = bundle.interfaces;
-  const isOwner = !!user?.email && !!meta?.author && user.email === meta.author;
+  const ownerEmail = meta?._ownerEmail ?? meta?.author ?? '';
+  const isOwner = !!user?.email && !!ownerEmail && user.email === ownerEmail;
+  const authorVerified =
+    ownerEmail.includes('@') &&
+    ownerEmail.toLowerCase().endsWith('@calimero.network');
   const userEmailLower = user?.email?.toLowerCase() ?? '';
   const isOrgMember =
     !!userEmailLower &&
@@ -214,7 +220,12 @@ export default function AppDetailPage() {
       {/* Info grid */}
       <div className='grid grid-cols-2 md:grid-cols-4 gap-3'>
         {meta?.author && (
-          <InfoCard icon={User} label='Author' value={meta.author} />
+          <InfoCard
+            icon={User}
+            label='Author'
+            value={meta.author}
+            verified={authorVerified}
+          />
         )}
         <InfoCard icon={Clock} label='Version' value={bundle.appVersion} />
         {meta?.license && (
@@ -381,10 +392,13 @@ export default function AppDetailPage() {
           </p>
           <div className='space-y-1.5'>
             {allBundles.map(b => {
+              const vOwnerEmail =
+                b.metadata?._ownerEmail ?? b.metadata?.author ?? '';
               const isVersionOwner =
-                !!user?.email &&
-                !!b.metadata?.author &&
-                user.email === b.metadata.author;
+                !!user?.email && !!vOwnerEmail && user.email === vOwnerEmail;
+              const vAuthorVerified =
+                vOwnerEmail.includes('@') &&
+                vOwnerEmail.toLowerCase().endsWith('@calimero.network');
               const canEditVersion = isVersionOwner || isOrgMember;
               const isConfirmingThisVersion =
                 confirmDeleteVersion === b.appVersion;
@@ -400,8 +414,11 @@ export default function AppDetailPage() {
                     </span>
                   </div>
                   <div className='flex items-center gap-3'>
-                    <span className='text-[11px] text-neutral-500 font-mono'>
+                    <span className='inline-flex items-center gap-1 text-[11px] text-neutral-500 font-mono'>
                       {b.metadata?.author || ''}
+                      {vAuthorVerified && (
+                        <BadgeCheck className='h-3.5 w-3.5 flex-shrink-0 text-emerald-400' />
+                      )}
                     </span>
                     {canEditVersion && (
                       <Link
@@ -519,18 +536,23 @@ function InfoCard({
   icon: Icon,
   label,
   value,
+  verified,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   label: string;
   value: string;
+  verified?: boolean;
 }) {
   return (
     <div className='card px-3.5 py-2.5 flex items-center gap-2.5'>
       <Icon className='w-3.5 h-3.5 text-neutral-500 flex-shrink-0' />
       <div className='min-w-0'>
         <p className='text-[11px] text-neutral-500'>{label}</p>
-        <p className='text-[13px] text-neutral-200 font-light truncate'>
+        <p className='text-[13px] text-neutral-200 font-light truncate flex items-center gap-1'>
           {value}
+          {verified && (
+            <BadgeCheck className='h-3.5 w-3.5 flex-shrink-0 text-emerald-400' />
+          )}
         </p>
       </div>
     </div>

--- a/packages/frontend/src/pages/AppsPage.tsx
+++ b/packages/frontend/src/pages/AppsPage.tsx
@@ -1,7 +1,13 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { Search, Package, ArrowUpRight, Download } from 'lucide-react';
+import {
+  Search,
+  Package,
+  ArrowUpRight,
+  Download,
+  BadgeCheck,
+} from 'lucide-react';
 import { getApps } from '../lib/api';
 import type { AppSummary } from '../types/api';
 
@@ -123,8 +129,13 @@ function AppCard({ app }: { app: AppSummary }) {
         {app.package_name}
       </p>
       <div className='flex items-center justify-between'>
-        <span className='text-[11px] text-neutral-400 font-light'>
-          {app.developer?.display_name || app.developer_pubkey}
+        <span className='inline-flex items-center gap-1 text-[11px] text-neutral-400 font-light min-w-0'>
+          <span className='truncate font-mono'>
+            {app.developer?.display_name || app.developer_pubkey}
+          </span>
+          {app.verified && (
+            <BadgeCheck className='h-3.5 w-3.5 flex-shrink-0 text-emerald-400' />
+          )}
         </span>
         <div className='flex items-center gap-2'>
           <span className='flex items-center gap-1 text-[11px] text-neutral-500'>

--- a/packages/frontend/src/pages/DeveloperDetailPage.tsx
+++ b/packages/frontend/src/pages/DeveloperDetailPage.tsx
@@ -1,7 +1,13 @@
 import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Package, User, ArrowLeft, ArrowUpRight } from 'lucide-react';
-import { api } from '@/lib/api';
+import {
+  Package,
+  User,
+  ArrowLeft,
+  ArrowUpRight,
+  BadgeCheck,
+} from 'lucide-react';
+import { api, resolveUsers } from '@/lib/api';
 
 interface V2Bundle {
   version: string;
@@ -34,6 +40,18 @@ export default function DeveloperDetailPage() {
   const developerBundles = allBundles.filter(
     b => b.metadata?.author === decodedName
   );
+
+  const { data: userMap = {} } = useQuery({
+    queryKey: ['resolve-user', decodedName],
+    queryFn: () => resolveUsers([decodedName]),
+    enabled: !!decodedName,
+  });
+  const developerProfile = userMap[decodedName] as
+    | { username: string | null; verified: boolean }
+    | undefined;
+  const displayName = developerProfile?.username
+    ? `@${developerProfile.username}`
+    : decodedName;
 
   const uniqueApps = new Map<string, V2Bundle>();
   for (const b of developerBundles) {
@@ -78,8 +96,11 @@ export default function DeveloperDetailPage() {
           <User className='w-4 h-4 text-neutral-400' />
         </div>
         <div>
-          <h1 className='text-xl font-semibold text-neutral-100'>
-            {decodedName}
+          <h1 className='flex items-center gap-2 text-xl font-semibold text-neutral-100'>
+            <span className='font-mono'>{displayName}</span>
+            {developerProfile?.verified && (
+              <BadgeCheck className='h-5 w-5 text-emerald-400 flex-shrink-0' />
+            )}
           </h1>
           <p className='text-[12px] text-neutral-500 font-light'>
             {apps.length} app{apps.length !== 1 ? 's' : ''} &middot;{' '}

--- a/packages/frontend/src/pages/DevelopersPage.tsx
+++ b/packages/frontend/src/pages/DevelopersPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Search, Package, User, ArrowUpRight } from 'lucide-react';
+import { Search, Package, User, ArrowUpRight, BadgeCheck } from 'lucide-react';
 import { getApps } from '@/lib/api';
 
 export default function DevelopersPage() {
@@ -12,24 +12,29 @@ export default function DevelopersPage() {
     queryFn: () => getApps(),
   });
 
-  const developers = Array.from(
+  const uniqueAuthors = Array.from(
     new Set(
       apps.map(app => app.developer_pubkey).filter(a => a && a !== 'Unknown')
     )
-  ).map(author => {
+  );
+
+  const developers = uniqueAuthors.map(author => {
     const developerApps = apps.filter(app => app.developer_pubkey === author);
     return {
       pubkey: author,
+      verified: developerApps.some(app => app.verified),
       appCount: developerApps.length,
       latestApp: developerApps[0]?.name || 'Unknown',
     };
   });
 
-  const filteredDevelopers = developers.filter(
-    dev =>
-      dev.pubkey.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      dev.latestApp.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const filteredDevelopers = developers.filter(dev => {
+    const q = searchTerm.toLowerCase();
+    return (
+      dev.pubkey.toLowerCase().includes(q) ||
+      dev.latestApp.toLowerCase().includes(q)
+    );
+  });
 
   if (isLoading) {
     return (
@@ -93,11 +98,17 @@ export default function DevelopersPage() {
 function DeveloperCard({
   developer,
 }: {
-  developer: { pubkey: string; appCount: number; latestApp: string };
+  developer: {
+    pubkey: string;
+    verified: boolean;
+    appCount: number;
+    latestApp: string;
+  };
 }) {
+  const displayName = developer.pubkey;
   return (
     <Link
-      to={`/developers/${developer.pubkey}`}
+      to={`/developers/${encodeURIComponent(developer.pubkey)}`}
       className='card block px-4 py-3 group hover:border-brand-600/30'
     >
       <div className='flex items-center justify-between'>
@@ -106,8 +117,11 @@ function DeveloperCard({
             <User className='w-3.5 h-3.5 text-neutral-400' />
           </div>
           <div className='min-w-0'>
-            <h3 className='text-[13px] font-medium text-neutral-200 truncate group-hover:text-white transition-colors'>
-              {developer.pubkey}
+            <h3 className='flex items-center gap-1.5 text-[13px] font-medium text-neutral-200 truncate group-hover:text-white transition-colors'>
+              <span className='font-mono truncate'>{displayName}</span>
+              {developer.verified && (
+                <BadgeCheck className='h-3.5 w-3.5 flex-shrink-0 text-emerald-400' />
+              )}
             </h3>
             <p className='text-[11px] text-neutral-500 font-light'>
               Latest: {developer.latestApp}

--- a/packages/frontend/src/pages/OrgDetailPage.tsx
+++ b/packages/frontend/src/pages/OrgDetailPage.tsx
@@ -41,6 +41,7 @@ import {
   Twitter,
   MapPin,
   ExternalLink,
+  BadgeCheck,
 } from 'lucide-react';
 
 /** Extract a readable message from an Axios or generic error. */
@@ -504,12 +505,21 @@ export default function OrgDetailPage() {
                       className='border-b border-neutral-800/80 last:border-0'
                     >
                       <td className='py-3 px-5 text-neutral-400 truncate max-w-[280px]'>
-                        {member.email}
-                        {isCurrentUserRow && (
-                          <span className='ml-2 text-[10px] text-brand-600'>
-                            (you)
+                        <span className='inline-flex items-center gap-1.5'>
+                          <span className='font-mono'>
+                            {member.username
+                              ? `@${member.username}`
+                              : '(no username)'}
                           </span>
-                        )}
+                          {member.verified && (
+                            <BadgeCheck className='h-3.5 w-3.5 flex-shrink-0 text-emerald-400' />
+                          )}
+                          {isCurrentUserRow && (
+                            <span className='text-[10px] text-brand-600'>
+                              (you)
+                            </span>
+                          )}
+                        </span>
                       </td>
                       <td className='py-3 px-5'>
                         {member.role === 'owner' ? (

--- a/packages/frontend/src/types/api.ts
+++ b/packages/frontend/src/types/api.ts
@@ -6,10 +6,12 @@ export interface AppSummary {
   latest_version: string;
   alias?: string;
   downloads?: number;
+  verified?: boolean;
   developer?: {
     display_name: string;
     website?: string;
     pubkey: string;
+    verified?: boolean;
   };
 }
 
@@ -96,6 +98,8 @@ export interface Org {
 
 export interface OrgMember {
   email: string;
+  username: string | null;
+  verified?: boolean;
   role: 'owner' | 'admin' | 'member';
 }
 


### PR DESCRIPTION
feat: add username first logic registry

## Description
Removed emails and registry is not username first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Redis-backed user profile/username flow and changes bundle ownership checks to use `_ownerEmail`, which can affect auth/authorization and publishing/deletion behavior. Also introduces a public, unauthenticated download recording endpoint that could be abused to inflate counters if not rate-limited upstream.
> 
> **Overview**
> **Shifts the registry to be username-first.** Backend now persists user profiles in Redis, enriches `/api/auth/me` with `username`/`verified`, and adds `POST /api/auth/username` plus `GET /api/users/resolve` for claiming and resolving usernames.
> 
> **Updates bundle ownership + author semantics.** Publishing stores `metadata.author` as the display name (username preferred) and adds `metadata._ownerEmail` for ownership checks; list/delete/edit filters are updated to use `_ownerEmail` (with legacy fallback). Org member listing now returns `username`/`verified` instead of exposing emails in the UI.
> 
> **Adds download counting plumbing.** KV client gains `incr`, download keys are canonicalized to lowercase, bundle APIs return `downloads`, and a new public `POST /api/v2/downloads/record` increments counters. Frontend displays usernames and verification badges, prompts logged-in users to set a username via a modal, and wires new API helpers/types. A `clear-registry` script was added to flush Redis for local/dev resets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35de8206d4397e51d66979d14053bb56a3650030. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->