### PR TITLE
fix: vercel serverless auth usernames

### DIFF
--- a/api/auth/google/callback.js
+++ b/api/auth/google/callback.js
@@ -3,6 +3,7 @@
  */
 
 const jwt = require('jsonwebtoken');
+const { getOrCreateUser } = require('../../lib/user-storage');
 
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
@@ -87,6 +88,13 @@ module.exports = async function handler(req, res) {
   } catch {
     res.setHeader('Location', `${frontendUrl}?error=oauth_failed`);
     return res.status(302).end();
+  }
+
+  // Persist user profile in Redis (creates on first login, updates name/picture on subsequent logins)
+  try {
+    await getOrCreateUser(user);
+  } catch {
+    // Non-fatal — session still works without Redis profile
   }
 
   const token = jwt.sign(

--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -4,6 +4,7 @@
 
 const jwt = require('jsonwebtoken');
 const { kv } = require('../lib/kv-client');
+const { getUserById, getUserByEmail } = require('../lib/user-storage');
 
 const TOKEN_PREFIX = 'apitoken:';
 
@@ -35,18 +36,24 @@ module.exports = async function handler(req, res) {
   const cookieName = process.env.AUTH_COOKIE_NAME || 'app_registry_session';
   const sessionSecret = process.env.SESSION_SECRET;
 
-  // 1) Try Bearer API token (same Redis key as backend)
+  // 1) Try Bearer API token
   const bearer = getBearerToken(req);
   if (bearer) {
     try {
       const raw = await kv.get(TOKEN_PREFIX + bearer);
       if (raw) {
         const data = JSON.parse(typeof raw === 'string' ? raw : String(raw));
+        const profile = await getUserByEmail(data.email);
         return res.status(200).json({
           user: {
+            id: data.email,
             email: data.email,
             name: data.name ?? data.email,
-            pubkey: data.pubkey ?? null,
+            picture: null,
+            username: profile?.username ?? null,
+            verified:
+              profile?.verified ??
+              (data.email || '').endsWith('@calimero.network'),
           },
         });
       }
@@ -67,12 +74,18 @@ module.exports = async function handler(req, res) {
 
   try {
     const payload = jwt.verify(token, sessionSecret, { algorithms: ['HS256'] });
+    const profile =
+      (await getUserById(payload.sub)) || (await getUserByEmail(payload.email));
     return res.status(200).json({
       user: {
         id: payload.sub,
         email: payload.email,
         name: payload.name,
         picture: payload.picture,
+        username: profile?.username ?? null,
+        verified:
+          profile?.verified ??
+          (payload.email || '').endsWith('@calimero.network'),
       },
     });
   } catch {

--- a/api/auth/username.js
+++ b/api/auth/username.js
@@ -1,0 +1,44 @@
+/**
+ * POST /api/auth/username — claim a username (immutable once set)
+ */
+
+const { requireAuth } = require('../lib/auth-helpers');
+const { claimUsername } = require('../lib/user-storage');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const user = await requireAuth(req, res);
+  if (!user) return;
+
+  const { username } = req.body || {};
+  if (!username || typeof username !== 'string') {
+    return res
+      .status(400)
+      .json({ error: 'bad_request', message: 'username is required' });
+  }
+
+  // userId: prefer sub from JWT, fall back to email as key
+  const userId = user.id || user.email;
+
+  try {
+    const updated = await claimUsername(userId, username.trim());
+    return res.status(200).json({ username: updated.username });
+  } catch (err) {
+    const code = err.code;
+    if (code === 'invalid_format')
+      return res
+        .status(400)
+        .json({ error: 'invalid_format', message: err.message });
+    if (code === 'blocked')
+      return res.status(400).json({ error: 'blocked', message: err.message });
+    if (code === 'taken')
+      return res.status(409).json({ error: 'taken', message: err.message });
+    if (code === 'immutable')
+      return res.status(409).json({ error: 'immutable', message: err.message });
+    console.error('POST /api/auth/username failed:', err);
+    return res
+      .status(500)
+      .json({ error: 'server_error', message: 'Failed to set username' });
+  }
+};

--- a/api/lib/auth-helpers.js
+++ b/api/lib/auth-helpers.js
@@ -60,7 +60,8 @@ async function resolveUser(req) {
         const payload = jwt.verify(token, sessionSecret, {
           algorithms: ['HS256'],
         });
-        if (payload?.email) return { email: payload.email, name: payload.name };
+        if (payload?.email)
+          return { id: payload.sub, email: payload.email, name: payload.name };
       } catch {
         /* fall through */
       }

--- a/api/lib/user-storage.js
+++ b/api/lib/user-storage.js
@@ -1,0 +1,172 @@
+/**
+ * User profile storage (Redis) — shared by Vercel serverless functions.
+ * Keys:
+ *   user:{userId}          → JSON { id, email, username, verified, name, picture, createdAt }
+ *   username:{username}    → userId  (uniqueness index)
+ *   email2user:{email}     → userId  (reverse lookup)
+ */
+
+const { kv } = require('./kv-client');
+
+const USER_PREFIX = 'user:';
+const USERNAME_PREFIX = 'username:';
+const EMAIL2USER_PREFIX = 'email2user:';
+
+const USERNAME_REGEX = /^[a-z0-9]([a-z0-9_-]{0,48}[a-z0-9])?$/;
+
+const BLOCKED_TERMS = new Set([
+  'fuck',
+  'shit',
+  'ass',
+  'bitch',
+  'bastard',
+  'cunt',
+  'dick',
+  'pussy',
+  'cock',
+  'nigger',
+  'nigga',
+  'faggot',
+  'fag',
+  'whore',
+  'slut',
+  'retard',
+  'rape',
+  'piss',
+  'prick',
+  'twat',
+  'wanker',
+  'asshole',
+  'arsehole',
+  'bullshit',
+  'nazi',
+  'hitler',
+  'admin',
+  'administrator',
+  'root',
+  'system',
+  'support',
+  'moderator',
+  'calimero',
+  'calimeronetwork',
+]);
+
+function containsBlockedTerm(username) {
+  const lower = username.toLowerCase().replace(/[-_]/g, '');
+  for (const term of BLOCKED_TERMS) {
+    if (lower.includes(term)) return true;
+  }
+  return false;
+}
+
+async function getUserById(userId) {
+  if (!userId) return null;
+  const raw = await kv.get(USER_PREFIX + String(userId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(typeof raw === 'string' ? raw : String(raw));
+  } catch {
+    return null;
+  }
+}
+
+async function getUserByEmail(email) {
+  if (!email) return null;
+  const norm = email.toLowerCase();
+  const rawId = await kv.get(EMAIL2USER_PREFIX + norm);
+  if (!rawId) return null;
+  return getUserById(typeof rawId === 'string' ? rawId : String(rawId));
+}
+
+async function getUserByUsername(username) {
+  if (!username) return null;
+  const norm = username.toLowerCase();
+  const rawId = await kv.get(USERNAME_PREFIX + norm);
+  if (!rawId) return null;
+  return getUserById(typeof rawId === 'string' ? rawId : String(rawId));
+}
+
+async function getOrCreateUser(googleUser) {
+  const { id, email, name, picture } = googleUser;
+  const emailNorm = (email || '').toLowerCase();
+  const verified = emailNorm.endsWith('@calimero.network');
+
+  const rawUserId = await kv.get(EMAIL2USER_PREFIX + emailNorm);
+  if (rawUserId) {
+    const userId =
+      typeof rawUserId === 'string' ? rawUserId : String(rawUserId);
+    const raw = await kv.get(USER_PREFIX + userId);
+    if (raw) {
+      const existing = JSON.parse(typeof raw === 'string' ? raw : String(raw));
+      const updated = {
+        ...existing,
+        name: name || existing.name,
+        picture: picture || existing.picture,
+        verified,
+      };
+      await kv.set(USER_PREFIX + userId, JSON.stringify(updated));
+      return updated;
+    }
+  }
+
+  const user = {
+    id,
+    email: emailNorm,
+    name: name || emailNorm,
+    picture: picture || null,
+    username: null,
+    verified,
+    createdAt: new Date().toISOString(),
+  };
+  await kv.set(USER_PREFIX + id, JSON.stringify(user));
+  await kv.set(EMAIL2USER_PREFIX + emailNorm, id);
+  return user;
+}
+
+async function claimUsername(userId, username) {
+  const norm = username.toLowerCase();
+  if (!USERNAME_REGEX.test(norm)) {
+    const err = new Error(
+      'Username must be 2–50 characters, use only letters, numbers, underscores, or hyphens, and start and end with a letter or number'
+    );
+    err.code = 'invalid_format';
+    throw err;
+  }
+  if (containsBlockedTerm(norm)) {
+    const err = new Error('This username is not allowed');
+    err.code = 'blocked';
+    throw err;
+  }
+  const existingOwner = await kv.get(USERNAME_PREFIX + norm);
+  if (existingOwner && String(existingOwner) !== String(userId)) {
+    const err = new Error('This username is already taken');
+    err.code = 'taken';
+    throw err;
+  }
+  const raw = await kv.get(USER_PREFIX + String(userId));
+  if (!raw) {
+    const err = new Error('User not found');
+    err.code = 'not_found';
+    throw err;
+  }
+  const user = JSON.parse(typeof raw === 'string' ? raw : String(raw));
+  if (user.username) {
+    const err = new Error(
+      'Username has already been set and cannot be changed'
+    );
+    err.code = 'immutable';
+    throw err;
+  }
+  user.username = norm;
+  await kv.set(USER_PREFIX + String(userId), JSON.stringify(user));
+  await kv.set(USERNAME_PREFIX + norm, String(userId));
+  return user;
+}
+
+module.exports = {
+  getOrCreateUser,
+  getUserById,
+  getUserByEmail,
+  getUserByUsername,
+  claimUsername,
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication/session handling and introduces Redis-backed user profile state (username/verified), which could affect login identity and `me` responses if keys or lookups are wrong. Changes are bounded to profile enrichment and a new endpoint, with fallbacks when Redis is unavailable.
> 
> **Overview**
> Persists Google OAuth logins into a Redis-backed user profile store and enriches `GET /api/auth/me` responses with `username` and `verified` (derived from stored profile, with an email-domain fallback).
> 
> Adds `POST /api/auth/username` to let authenticated users claim an **immutable** username with validation (format, blocked terms) and uniqueness enforced via Redis indexes; updates auth helpers to expose `id` from the session JWT for downstream operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4c7f34ffef1cca8eafb5c29763cb6dbff641900. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->