### PR TITLE
feat: reject dev-signed bundles on publish

### DIFF
--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -732,6 +732,19 @@ async function buildServer() {
         },
       };
     }
+    const DEV_SIGNER_ID =
+      'did:key:z6MknF3p5L5FDHJQ7FREUapuX4Wmp4MtF6WrHYaXS2B3eZQd';
+    if (bundleManifest.signerId === DEV_SIGNER_ID) {
+      throw {
+        statusCode: 403,
+        body: {
+          error: 'dev_signed_bundle',
+          message:
+            'Development-signed bundles cannot be published to the registry. Build with a release key: mero-sign sign manifest.json --key <release-key.json>',
+        },
+      };
+    }
+
     const incomingKey = getPublicKeyFromManifest(bundleManifest);
     const versions = await bundleStorage.getBundleVersions(
       bundleManifest.package


### PR DESCRIPTION
## Summary
- Reject bundles signed with `DEV_SIGNER_ID` on the publish endpoint (403)
- Safety net against accidental dev-to-prod promotion

## Related PRs
- core: calimero-network/core#2084

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new validation gate in the publish flow that will hard-fail (403) for manifests with a specific `signerId`, which could block legitimate releases if `signerId` is missing/misconfigured or the constant is wrong.
> 
> **Overview**
> Publishing now explicitly rejects bundles signed with the hardcoded development signer DID (`DEV_SIGNER_ID`) by returning a `403 dev_signed_bundle` error with guidance to re-sign using a release key.
> 
> This check is enforced in the shared `processPushBody` path, so it applies to both JSON pushes and `.mpk` uploads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c6bc547c27186c4a00168d2101d14ea778d5210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->