### PR TITLE
feat: multi-service bundles (main app + services)

### DIFF
--- a/packages/backend/api.yml
+++ b/packages/backend/api.yml
@@ -146,14 +146,20 @@ components:
             author:
               type: string
         wasm:
-          type: object
-          properties:
-            path:
-              type: string
-            hash:
-              type: string
-            size:
-              type: integer
+          description: The main application WASM artifact (packed as app.wasm).
+          $ref: '#/components/schemas/BundleArtifact'
+        abi:
+          description: The main application ABI artifact (packed as abi.json), if any.
+          $ref: '#/components/schemas/BundleArtifact'
+        services:
+          type: array
+          description: >-
+            Additional named services shipped alongside the main app (e.g. a
+            "lobby" service next to a "tictactoe" main app). Optional and
+            omitted entirely for single-app bundles, so existing manifests and
+            their signatures are unaffected.
+          items:
+            $ref: '#/components/schemas/BundleServiceEntry'
         links:
           type: object
           properties:
@@ -174,3 +180,31 @@ components:
               type: string
             signedAt:
               type: string
+    BundleArtifact:
+      type: object
+      description: A file packed in the bundle, referenced by its in-bundle path.
+      properties:
+        path:
+          type: string
+          description: Path of the file within the bundle (e.g. app.wasm, services/lobby.wasm).
+        hash:
+          type: string
+          nullable: true
+          description: SHA-256 hex digest of the file contents.
+        size:
+          type: integer
+          description: File size in bytes.
+    BundleServiceEntry:
+      type: object
+      required:
+        - name
+        - wasm
+      description: A named service shipped alongside the main application.
+      properties:
+        name:
+          type: string
+          description: Service name; also its file stem under services/.
+        wasm:
+          $ref: '#/components/schemas/BundleArtifact'
+        abi:
+          $ref: '#/components/schemas/BundleArtifact'

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -62,6 +62,14 @@ class BundleStorageKV {
     // reserved "app") — a client bypassing the CLI must not be able to persist
     // a name like "../evil" or "app" that becomes a filesystem path segment
     // when a consumer later unpacks the bundle.
+    //
+    // NOTE: SERVICE_NAME_RE and these rules are mirrored in the CLI's
+    // packages/cli/src/lib/services.ts (validateServiceName). The two are not
+    // shared at the module level (CJS backend vs ESM/TS CLI build), so keep
+    // them in sync — any change here must be reflected there and vice versa.
+    // The name is validated as-is (not trimmed): the regex already rejects
+    // whitespace, and trimming server-side would diverge the stored manifest
+    // from the bytes the signature was computed over.
     if (manifestJson.services !== undefined && manifestJson.services !== null) {
       if (!Array.isArray(manifestJson.services)) {
         throw new Error('Invalid services: must be an array or undefined/null');
@@ -72,19 +80,22 @@ class BundleStorageKV {
         if (!svc || typeof svc !== 'object' || Array.isArray(svc)) {
           throw new Error('Invalid service: each service must be an object');
         }
-        if (typeof svc.name !== 'string' || svc.name.trim().length === 0) {
+        if (typeof svc.name !== 'string' || svc.name.length === 0) {
           throw new Error('Invalid service: missing or empty name');
         }
-        const name = svc.name.trim();
-        if (!SERVICE_NAME_RE.test(name) || name.length > 64 || name === 'app') {
+        if (
+          !SERVICE_NAME_RE.test(svc.name) ||
+          svc.name.length > 64 ||
+          svc.name === 'app'
+        ) {
           throw new Error(
             `Invalid service name "${svc.name}": must match ^[a-z0-9][a-z0-9_-]*$, be at most 64 chars, and not be "app"`
           );
         }
-        if (seenNames.has(name)) {
-          throw new Error(`Invalid service: duplicate name "${name}"`);
+        if (seenNames.has(svc.name)) {
+          throw new Error(`Invalid service: duplicate name "${svc.name}"`);
         }
-        seenNames.add(name);
+        seenNames.add(svc.name);
         if (
           !svc.wasm ||
           typeof svc.wasm !== 'object' ||

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -8,6 +8,24 @@ const { kv } = require('./kv-client');
 const blob = require('./blob-store');
 const semver = require('semver');
 
+/**
+ * True if a bundle artifact path is NOT a safe, bundle-relative path: it is a
+ * non-string, empty, absolute, or contains a `.`/`..`/empty segment. Mirrors
+ * the CLI's assertSafeBundlePath (packages/cli/src/lib/services.ts); keep the
+ * two in sync.
+ */
+function isUnsafeBundlePath(p) {
+  if (typeof p !== 'string' || p.length === 0) return true;
+  const segments = p.split(/[\\/]/);
+  return (
+    p.startsWith('/') ||
+    /^[a-zA-Z]:/.test(p) ||
+    segments.includes('..') ||
+    segments.includes('.') ||
+    segments.includes('')
+  );
+}
+
 class BundleStorageKV {
   constructor() {
     // No in-memory state needed - all operations use KV
@@ -104,6 +122,27 @@ class BundleStorageKV {
           throw new Error(
             `Invalid service "${svc.name}": missing wasm artifact`
           );
+        }
+        // Validate artifact paths so a client bypassing the CLI can't persist
+        // a wasm/abi path like '../../etc/passwd' that a downstream consumer
+        // might trust when reconstructing files. Mirrors the CLI's
+        // assertSafeBundlePath (packages/cli/src/lib/services.ts).
+        if (isUnsafeBundlePath(svc.wasm.path)) {
+          throw new Error(
+            `Invalid service "${svc.name}": unsafe wasm.path "${svc.wasm.path}"`
+          );
+        }
+        if (svc.abi !== undefined && svc.abi !== null) {
+          if (typeof svc.abi !== 'object' || Array.isArray(svc.abi)) {
+            throw new Error(
+              `Invalid service "${svc.name}": abi must be an artifact object`
+            );
+          }
+          if (isUnsafeBundlePath(svc.abi.path)) {
+            throw new Error(
+              `Invalid service "${svc.name}": unsafe abi.path "${svc.abi.path}"`
+            );
+          }
         }
       }
     }

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -57,11 +57,16 @@ class BundleStorageKV {
 
     // Validate services structure before storage to prevent partial writes.
     // Services are optional; when present they must be an array of named
-    // entries each carrying a wasm artifact. Names must be unique.
+    // entries each carrying a wasm artifact. The backend is the authoritative
+    // store, so it enforces the same name rules as the CLI (charset, length,
+    // reserved "app") — a client bypassing the CLI must not be able to persist
+    // a name like "../evil" or "app" that becomes a filesystem path segment
+    // when a consumer later unpacks the bundle.
     if (manifestJson.services !== undefined && manifestJson.services !== null) {
       if (!Array.isArray(manifestJson.services)) {
         throw new Error('Invalid services: must be an array or undefined/null');
       }
+      const SERVICE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
       const seenNames = new Set();
       for (const svc of manifestJson.services) {
         if (!svc || typeof svc !== 'object' || Array.isArray(svc)) {
@@ -70,10 +75,16 @@ class BundleStorageKV {
         if (typeof svc.name !== 'string' || svc.name.trim().length === 0) {
           throw new Error('Invalid service: missing or empty name');
         }
-        if (seenNames.has(svc.name)) {
-          throw new Error(`Invalid service: duplicate name "${svc.name}"`);
+        const name = svc.name.trim();
+        if (!SERVICE_NAME_RE.test(name) || name.length > 64 || name === 'app') {
+          throw new Error(
+            `Invalid service name "${svc.name}": must match ^[a-z0-9][a-z0-9_-]*$, be at most 64 chars, and not be "app"`
+          );
         }
-        seenNames.add(svc.name);
+        if (seenNames.has(name)) {
+          throw new Error(`Invalid service: duplicate name "${name}"`);
+        }
+        seenNames.add(name);
         if (
           !svc.wasm ||
           typeof svc.wasm !== 'object' ||

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -55,6 +55,33 @@ class BundleStorageKV {
       }
     }
 
+    // Validate services structure before storage to prevent partial writes.
+    // Services are optional; when present they must be an array of named
+    // entries each carrying a wasm artifact. Names must be unique.
+    if (manifestJson.services !== undefined && manifestJson.services !== null) {
+      if (!Array.isArray(manifestJson.services)) {
+        throw new Error('Invalid services: must be an array or undefined/null');
+      }
+      const seenNames = new Set();
+      for (const svc of manifestJson.services) {
+        if (!svc || typeof svc !== 'object' || Array.isArray(svc)) {
+          throw new Error('Invalid service: each service must be an object');
+        }
+        if (typeof svc.name !== 'string' || svc.name.trim().length === 0) {
+          throw new Error('Invalid service: missing or empty name');
+        }
+        if (seenNames.has(svc.name)) {
+          throw new Error(`Invalid service: duplicate name "${svc.name}"`);
+        }
+        seenNames.add(svc.name);
+        if (!svc.wasm || typeof svc.wasm !== 'object') {
+          throw new Error(
+            `Invalid service "${svc.name}": missing wasm artifact`
+          );
+        }
+      }
+    }
+
     // Upload the binary to GCS BEFORE writing the manifest, so a manifest can
     // never exist in Redis without its blob in the bucket. If the upload throws,
     // we bail out here and nothing is written. (Re-uploading the same

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -26,6 +26,16 @@ function isUnsafeBundlePath(p) {
   );
 }
 
+/**
+ * True if a service artifact path lives under the `services/` directory (the
+ * layout the CLI emits). Combined with isUnsafeBundlePath this stops a service
+ * artifact from claiming a top-level name like `app.wasm` and colliding with
+ * the main application on unpack.
+ */
+function underServicesDir(p) {
+  return typeof p === 'string' && /^services[\\/]/.test(p);
+}
+
 class BundleStorageKV {
   constructor() {
     // No in-memory state needed - all operations use KV
@@ -126,10 +136,15 @@ class BundleStorageKV {
         // Validate artifact paths so a client bypassing the CLI can't persist
         // a wasm/abi path like '../../etc/passwd' that a downstream consumer
         // might trust when reconstructing files. Mirrors the CLI's
-        // assertSafeBundlePath (packages/cli/src/lib/services.ts).
-        if (isUnsafeBundlePath(svc.wasm.path)) {
+        // assertSafeBundlePath (packages/cli/src/lib/services.ts). Service
+        // artifacts must also live under `services/` so they can't collide
+        // with the main app's `app.wasm` / `abi.json`.
+        if (
+          isUnsafeBundlePath(svc.wasm.path) ||
+          !underServicesDir(svc.wasm.path)
+        ) {
           throw new Error(
-            `Invalid service "${svc.name}": unsafe wasm.path "${svc.wasm.path}"`
+            `Invalid service "${svc.name}": wasm.path "${svc.wasm.path}" must be a safe relative path under services/`
           );
         }
         if (svc.abi !== undefined && svc.abi !== null) {
@@ -138,9 +153,12 @@ class BundleStorageKV {
               `Invalid service "${svc.name}": abi must be an artifact object`
             );
           }
-          if (isUnsafeBundlePath(svc.abi.path)) {
+          if (
+            isUnsafeBundlePath(svc.abi.path) ||
+            !underServicesDir(svc.abi.path)
+          ) {
             throw new Error(
-              `Invalid service "${svc.name}": unsafe abi.path "${svc.abi.path}"`
+              `Invalid service "${svc.name}": abi.path "${svc.abi.path}" must be a safe relative path under services/`
             );
           }
         }

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -74,7 +74,11 @@ class BundleStorageKV {
           throw new Error(`Invalid service: duplicate name "${svc.name}"`);
         }
         seenNames.add(svc.name);
-        if (!svc.wasm || typeof svc.wasm !== 'object') {
+        if (
+          !svc.wasm ||
+          typeof svc.wasm !== 'object' ||
+          Array.isArray(svc.wasm)
+        ) {
           throw new Error(
             `Invalid service "${svc.name}": missing wasm artifact`
           );

--- a/packages/backend/tests/multi-service-bundle.test.js
+++ b/packages/backend/tests/multi-service-bundle.test.js
@@ -136,8 +136,14 @@ describe('Multi-service bundle storage', () => {
     const manifest = {
       ...baseManifest(),
       services: [
-        { name: 'lobby', wasm: { path: 'a.wasm', hash: 'h', size: 1 } },
-        { name: 'lobby', wasm: { path: 'b.wasm', hash: 'h', size: 2 } },
+        {
+          name: 'lobby',
+          wasm: { path: 'services/lobby.wasm', hash: 'h', size: 1 },
+        },
+        {
+          name: 'lobby',
+          wasm: { path: 'services/lobby2.wasm', hash: 'h', size: 2 },
+        },
       ],
     };
     await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
@@ -189,7 +195,20 @@ describe('Multi-service bundle storage', () => {
       ],
     };
     await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
-      /unsafe wasm.path/
+      /wasm.path .* under services\//
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
+  test('rejects a service wasm.path not under services/ (collision with app.wasm)', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [
+        { name: 'lobby', wasm: { path: 'app.wasm', hash: 'h', size: 1 } },
+      ],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      /wasm.path .* under services\//
     );
     expect(kv.setNX).not.toHaveBeenCalled();
   });
@@ -206,7 +225,7 @@ describe('Multi-service bundle storage', () => {
       ],
     };
     await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
-      /unsafe abi.path/
+      /abi.path .* under services\//
     );
     expect(kv.setNX).not.toHaveBeenCalled();
   });

--- a/packages/backend/tests/multi-service-bundle.test.js
+++ b/packages/backend/tests/multi-service-bundle.test.js
@@ -140,7 +140,13 @@ describe('Multi-service bundle storage', () => {
   });
 
   test('rejects a service name that violates the charset (e.g. traversal/uppercase)', async () => {
-    for (const bad of ['../evil', 'Lobby', 'has space', 'app']) {
+    // Each iteration is independent: clear state + assert per-name so a name
+    // that wrongly slipped through couldn't be masked by a later "already
+    // exists" error or a single end-of-loop assertion.
+    for (const bad of ['../evil', 'Lobby', 'has space', ' lobby ', 'app']) {
+      mockKVData.clear();
+      mockKVSets.clear();
+      jest.clearAllMocks();
       const manifest = {
         ...baseManifest(),
         services: [{ name: bad, wasm: { path: 'x.wasm', hash: 'h', size: 1 } }],
@@ -148,8 +154,8 @@ describe('Multi-service bundle storage', () => {
       await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
         /Invalid service name/
       );
+      expect(kv.setNX).not.toHaveBeenCalled();
     }
-    expect(kv.setNX).not.toHaveBeenCalled();
   });
 
   test('rejects a service name longer than 64 characters', async () => {

--- a/packages/backend/tests/multi-service-bundle.test.js
+++ b/packages/backend/tests/multi-service-bundle.test.js
@@ -138,4 +138,30 @@ describe('Multi-service bundle storage', () => {
     );
     expect(kv.setNX).not.toHaveBeenCalled();
   });
+
+  test('rejects a service name that violates the charset (e.g. traversal/uppercase)', async () => {
+    for (const bad of ['../evil', 'Lobby', 'has space', 'app']) {
+      const manifest = {
+        ...baseManifest(),
+        services: [{ name: bad, wasm: { path: 'x.wasm', hash: 'h', size: 1 } }],
+      };
+      await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+        /Invalid service name/
+      );
+    }
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
+  test('rejects a service name longer than 64 characters', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [
+        { name: 'a'.repeat(65), wasm: { path: 'x.wasm', hash: 'h', size: 1 } },
+      ],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      /Invalid service name/
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
 });

--- a/packages/backend/tests/multi-service-bundle.test.js
+++ b/packages/backend/tests/multi-service-bundle.test.js
@@ -114,6 +114,17 @@ describe('Multi-service bundle storage', () => {
     expect(kv.setNX).not.toHaveBeenCalled();
   });
 
+  test('rejects a service whose wasm is an array, not an object', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [{ name: 'lobby', wasm: [] }],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      'Invalid service "lobby": missing wasm artifact'
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
   test('rejects duplicate service names', async () => {
     const manifest = {
       ...baseManifest(),

--- a/packages/backend/tests/multi-service-bundle.test.js
+++ b/packages/backend/tests/multi-service-bundle.test.js
@@ -1,0 +1,130 @@
+/**
+ * Multi-service bundle storage tests.
+ *
+ * Verifies that the optional `services` array round-trips through storage
+ * untouched, that single-app bundles are unaffected (backward compat), and
+ * that malformed `services` are rejected before any partial write.
+ */
+
+const { BundleStorageKV } = require('../src/lib/bundle-storage-kv');
+
+const mockKVData = new Map();
+const mockKVSets = new Map();
+
+jest.mock('../src/lib/kv-client', () => ({
+  kv: {
+    set: jest.fn(async (key, value) => {
+      mockKVData.set(key, value);
+      return 'OK';
+    }),
+    get: jest.fn(async key => mockKVData.get(key) || null),
+    setNX: jest.fn(async (key, value) => {
+      if (mockKVData.has(key)) return false;
+      mockKVData.set(key, value);
+      return true;
+    }),
+    sAdd: jest.fn(async (key, value) => {
+      if (!mockKVSets.has(key)) mockKVSets.set(key, new Set());
+      mockKVSets.get(key).add(value);
+      return 1;
+    }),
+    sMembers: jest.fn(async key => {
+      const set = mockKVSets.get(key);
+      return set ? Array.from(set) : [];
+    }),
+  },
+}));
+
+const { kv } = require('../src/lib/kv-client');
+
+const baseManifest = () => ({
+  version: '1.0',
+  package: 'com.calimero.ttt',
+  appVersion: '1.0.0',
+  wasm: { path: 'app.wasm', hash: 'mainhash', size: 100 },
+  migrations: [],
+});
+
+const sampleServices = () => [
+  {
+    name: 'lobby',
+    wasm: { path: 'services/lobby.wasm', hash: 'lobbyhash', size: 50 },
+    abi: { path: 'services/lobby.abi.json', hash: 'lobbyabi', size: 10 },
+  },
+  {
+    name: 'chat',
+    wasm: { path: 'services/chat.wasm', hash: 'chathash', size: 60 },
+  },
+];
+
+describe('Multi-service bundle storage', () => {
+  let storage;
+
+  beforeEach(() => {
+    storage = new BundleStorageKV();
+    mockKVData.clear();
+    mockKVSets.clear();
+    jest.clearAllMocks();
+  });
+
+  test('round-trips a manifest with services intact', async () => {
+    const manifest = { ...baseManifest(), services: sampleServices() };
+    await storage.storeBundleManifest(manifest);
+
+    const got = await storage.getBundleManifest('com.calimero.ttt', '1.0.0');
+    expect(got.services).toEqual(sampleServices());
+    // Main app preserved alongside services.
+    expect(got.wasm).toEqual({ path: 'app.wasm', hash: 'mainhash', size: 100 });
+  });
+
+  test('single-app bundle stores without a services field (backward compat)', async () => {
+    await storage.storeBundleManifest(baseManifest());
+    const got = await storage.getBundleManifest('com.calimero.ttt', '1.0.0');
+    expect(got.services).toBeUndefined();
+    expect(got.wasm.path).toBe('app.wasm');
+  });
+
+  test('rejects non-array services', async () => {
+    const manifest = { ...baseManifest(), services: { name: 'lobby' } };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      'Invalid services: must be an array or undefined/null'
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
+  test('rejects a service without a name', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [{ wasm: { path: 'services/x.wasm', hash: 'h', size: 1 } }],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      'Invalid service: missing or empty name'
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
+  test('rejects a service without a wasm artifact', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [{ name: 'lobby' }],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      'Invalid service "lobby": missing wasm artifact'
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
+  test('rejects duplicate service names', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [
+        { name: 'lobby', wasm: { path: 'a.wasm', hash: 'h', size: 1 } },
+        { name: 'lobby', wasm: { path: 'b.wasm', hash: 'h', size: 2 } },
+      ],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      'Invalid service: duplicate name "lobby"'
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/tests/multi-service-bundle.test.js
+++ b/packages/backend/tests/multi-service-bundle.test.js
@@ -35,6 +35,13 @@ jest.mock('../src/lib/kv-client', () => ({
   },
 }));
 
+// Mock the blob store so any test that adds `_binary` to a manifest doesn't hit
+// real GCS (which throws when GCS_BUCKET is unset, e.g. in CI).
+jest.mock('../src/lib/blob-store', () => ({
+  putBinary: jest.fn(async () => {}),
+  getBinary: jest.fn(async () => null),
+}));
+
 const { kv } = require('../src/lib/kv-client');
 
 const baseManifest = () => ({
@@ -167,6 +174,39 @@ describe('Multi-service bundle storage', () => {
     };
     await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
       /Invalid service name/
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
+  test('rejects an unsafe service wasm.path', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [
+        {
+          name: 'lobby',
+          wasm: { path: '../../etc/passwd', hash: 'h', size: 1 },
+        },
+      ],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      /unsafe wasm.path/
+    );
+    expect(kv.setNX).not.toHaveBeenCalled();
+  });
+
+  test('rejects an unsafe service abi.path', async () => {
+    const manifest = {
+      ...baseManifest(),
+      services: [
+        {
+          name: 'lobby',
+          wasm: { path: 'services/lobby.wasm', hash: 'h', size: 1 },
+          abi: { path: '/etc/shadow', hash: 'h', size: 1 },
+        },
+      ],
+    };
+    await expect(storage.storeBundleManifest(manifest)).rejects.toThrow(
+      /unsafe abi.path/
     );
     expect(kv.setNX).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -746,6 +746,17 @@ Note:
             process.exit(1);
           }
 
+          // Each declared service must carry a wasm.path; otherwise it would be
+          // listed in the manifest but silently dropped from the archive.
+          for (const svc of dirManifest.services ?? []) {
+            if (!svc?.wasm?.path) {
+              console.error(
+                `❌ Service "${svc?.name ?? '<unnamed>'}" in manifest.json has no wasm.path.`
+              );
+              process.exit(1);
+            }
+          }
+
           // Collect the files to pack; rejects unsafe paths (absolute / "..")
           // that a crafted manifest could use to read outside the directory.
           let archiveFiles: string[];

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -419,6 +419,27 @@ Note:
         }
 
         for (const { src, baseDir } of allServiceSources) {
+          // Guard runtime types: manifest-config entries are parsed JSON, so
+          // `wasm`/`abi` could be objects (e.g. a BundleArtifact copied from a
+          // built manifest) rather than file-path strings. Without this,
+          // path.resolve would coerce an object to "[object Object]" and yield
+          // a misleading "not found" error.
+          if (typeof src.wasm !== 'string' || src.wasm.length === 0) {
+            console.error(
+              `❌ Service "${src.name}" wasm must be a file path string.`
+            );
+            process.exit(1);
+          }
+          if (
+            src.abi !== undefined &&
+            (typeof src.abi !== 'string' || src.abi.length === 0)
+          ) {
+            console.error(
+              `❌ Service "${src.name}" abi must be a file path string.`
+            );
+            process.exit(1);
+          }
+
           // Resolve + read the service WASM.
           const svcWasmPath = path.resolve(baseDir, src.wasm);
           if (!fs.existsSync(svcWasmPath)) {

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -567,11 +567,13 @@ Note:
         // Copy service files (under services/) preserving their archive paths.
         // Assert each destination stays inside outputDir/services/ — defence in
         // depth against a crafted name escaping the directory (e.g. "../app"),
-        // independent of validateServiceName.
-        const servicesPrefix = path.join(outputDir, 'services') + path.sep;
+        // independent of validateServiceName. Uses path.relative so the check
+        // is correct regardless of OS path separator.
+        const servicesDir = path.join(outputDir, 'services');
         for (const { relPath, content } of serviceFilesToWrite) {
           const dest = path.join(outputDir, relPath);
-          if (!dest.startsWith(servicesPrefix)) {
+          const rel = path.relative(servicesDir, dest);
+          if (rel.startsWith('..') || path.isAbsolute(rel)) {
             console.error(
               `❌ Refusing to write service file outside services/: ${relPath}`
             );
@@ -718,12 +720,11 @@ Note:
           // and was verified above, so a parse failure is a hard error — never
           // fall back silently, which would drop service files from the archive
           // while still reporting success.
-          let archiveFiles: string[];
+          let dirManifest: BundleManifest;
           try {
-            const dirManifest = JSON.parse(
+            dirManifest = JSON.parse(
               fs.readFileSync(manifestInDir, 'utf8')
             ) as BundleManifest;
-            archiveFiles = collectBundleFiles(dirManifest);
           } catch (e) {
             console.error(
               `❌ Failed to parse manifest.json in ${fullPath}: ${
@@ -733,6 +734,25 @@ Note:
             console.error(
               '   Fix the manifest JSON and retry (service files would otherwise be silently omitted).'
             );
+            process.exit(1);
+          }
+
+          // A bundle must declare its main app WASM; without it the archive
+          // would omit app.wasm and still "succeed".
+          if (!dirManifest.wasm?.path) {
+            console.error(
+              '❌ manifest.json has no main wasm (wasm.path). A bundle must include its main application.'
+            );
+            process.exit(1);
+          }
+
+          // Collect the files to pack; rejects unsafe paths (absolute / "..")
+          // that a crafted manifest could use to read outside the directory.
+          let archiveFiles: string[];
+          try {
+            archiveFiles = collectBundleFiles(dirManifest);
+          } catch (e) {
+            console.error(`❌ ${e instanceof Error ? e.message : String(e)}`);
             process.exit(1);
           }
 

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -11,10 +11,23 @@ import fs from 'fs';
 import path from 'path';
 import * as tar from 'tar';
 import crypto from 'crypto';
-import { LocalDataStore, BundleManifest } from '../lib/local-storage.js';
+import {
+  LocalDataStore,
+  BundleManifest,
+  BundleServiceEntry,
+} from '../lib/local-storage.js';
 import { LocalConfig } from '../lib/local-config.js';
 import { LocalArtifactServer } from '../lib/local-artifacts.js';
 import { RemoteConfig } from '../lib/remote-config.js';
+import {
+  ServiceSource,
+  parseServiceSpec,
+  validateServiceName,
+  serviceWasmPath,
+  serviceAbiPath,
+  assertUniqueServiceNames,
+  collectBundleFiles,
+} from '../lib/services.js';
 
 interface BundlePushPayload {
   version: string;
@@ -26,6 +39,7 @@ interface BundlePushPayload {
   interfaces?: BundleManifest['interfaces'];
   wasm?: BundleManifest['wasm'];
   abi?: BundleManifest['abi'];
+  services?: BundleManifest['services'];
   migrations?: BundleManifest['migrations'];
   links?: BundleManifest['links'];
   signature?: BundleManifest['signature'];
@@ -61,6 +75,8 @@ interface BundleManifestConfig {
   exports?: string[];
   uses?: string[];
   abi?: string | BundleManifest['abi']; // Can be file path string or BundleArtifact object
+  /** Additional services, each referencing source file paths (relative to this manifest). */
+  services?: ServiceSource[];
 }
 
 function createCreateCommand(): Command {
@@ -95,6 +111,13 @@ function createCreateCommand(): Command {
       }
     )
     .option('--abi <path>', 'Path to ABI JSON file to include in bundle')
+    .option(
+      '--service <spec>',
+      'Add a service WASM alongside the main app: "name=path.wasm" or "name=path.wasm,abi=path.json" (repeatable)',
+      (value, prev: ServiceSource[]) => {
+        return [...(prev || []), parseServiceSpec(value)];
+      }
+    )
     .addHelpText(
       'after',
       `
@@ -105,6 +128,7 @@ Examples:
   $ calimero-registry bundle create app.wasm com.calimero.myapp 1.0.0 --name "My App" --frontend https://app.example.com
   $ calimero-registry bundle create app.wasm com.calimero.myapp 1.0.0 --abi abi.json
   $ calimero-registry bundle create app.wasm --manifest manifest.json --abi res/abi.json
+  $ calimero-registry bundle create tictactoe.wasm com.calimero.ttt 1.0.0 --service lobby=lobby.wasm,abi=lobby-abi.json
 
 Manifest File Format (JSON):
   {
@@ -119,7 +143,10 @@ Manifest File Format (JSON):
     "docs": "https://docs.example.com",
     "exports": ["interface1", "interface2"],
     "uses": ["interface3"],
-    "abi": "res/abi.json"
+    "abi": "res/abi.json",
+    "services": [
+      { "name": "lobby", "wasm": "res/lobby.wasm", "abi": "res/lobby-abi.json" }
+    ]
   }
 
 Note:
@@ -129,6 +156,8 @@ Note:
   - The -o/--output option overrides manifest.output if both are provided
   - ABI can be provided via --abi flag or manifest.abi field (file path string)
   - ABI file will be included in the bundle and referenced in the manifest
+  - The main app is always packed as app.wasm; services are packed under services/<name>.wasm
+  - Services merge from --service flags and manifest.services; names must be unique
 `
     )
     .action(async (wasmFile, pkg, version, options) => {
@@ -339,6 +368,118 @@ Note:
           process.exit(1);
         }
 
+        // Handle services (additional WASMs alongside the main app).
+        // Sources come from --service flags (paths relative to cwd) and/or the
+        // manifest's "services" array (paths relative to the manifest file).
+        const cliServices: ServiceSource[] = options.service || [];
+        const manifestServices: ServiceSource[] = Array.isArray(
+          manifestConfig.services
+        )
+          ? manifestConfig.services
+          : [];
+        const manifestDir = options.manifest
+          ? path.dirname(path.resolve(options.manifest))
+          : process.cwd();
+
+        const allServiceSources: { src: ServiceSource; baseDir: string }[] = [
+          ...cliServices.map(src => ({ src, baseDir: process.cwd() })),
+          ...manifestServices.map(src => ({ src, baseDir: manifestDir })),
+        ];
+
+        const serviceArtifacts: BundleServiceEntry[] = [];
+        // Relative archive path -> file content, written into outputDir below.
+        const serviceFilesToWrite: { relPath: string; content: Buffer }[] = [];
+
+        // Reject duplicate names up front (covers --service + manifest overlap).
+        try {
+          assertUniqueServiceNames(allServiceSources.map(s => s.src));
+        } catch (e) {
+          console.error(`❌ ${e instanceof Error ? e.message : String(e)}`);
+          process.exit(1);
+        }
+
+        for (const { src, baseDir } of allServiceSources) {
+          // Manifest-sourced entries haven't been name-validated yet.
+          try {
+            validateServiceName(src.name);
+          } catch (e) {
+            console.error(`❌ ${e instanceof Error ? e.message : String(e)}`);
+            process.exit(1);
+          }
+
+          // Resolve + read the service WASM.
+          const svcWasmPath = path.resolve(baseDir, src.wasm);
+          if (!fs.existsSync(svcWasmPath)) {
+            console.error(
+              `❌ Service "${src.name}" WASM not found: ${src.wasm}`
+            );
+            console.error(`   Resolved path: ${svcWasmPath}`);
+            process.exit(1);
+          }
+          const svcWasmContent = fs.readFileSync(svcWasmPath);
+          const svcWasmHash = crypto
+            .createHash('sha256')
+            .update(svcWasmContent)
+            .digest('hex');
+          const wasmArchivePath = serviceWasmPath(src.name);
+
+          const entry: BundleServiceEntry = {
+            name: src.name,
+            wasm: {
+              path: wasmArchivePath,
+              hash: svcWasmHash,
+              size: svcWasmContent.length,
+            },
+          };
+          serviceFilesToWrite.push({
+            relPath: wasmArchivePath,
+            content: svcWasmContent,
+          });
+
+          // Resolve + read the optional service ABI.
+          if (src.abi) {
+            const svcAbiPath = path.resolve(baseDir, src.abi);
+            if (!fs.existsSync(svcAbiPath)) {
+              console.error(
+                `❌ Service "${src.name}" ABI not found: ${src.abi}`
+              );
+              console.error(`   Resolved path: ${svcAbiPath}`);
+              process.exit(1);
+            }
+            const svcAbiContent = fs.readFileSync(svcAbiPath);
+            try {
+              JSON.parse(svcAbiContent.toString('utf8'));
+            } catch (error) {
+              console.error(
+                `❌ Service "${src.name}" ABI is not valid JSON: ${src.abi}`
+              );
+              console.error(
+                error instanceof Error ? error.message : 'Invalid JSON'
+              );
+              process.exit(1);
+            }
+            const svcAbiHash = crypto
+              .createHash('sha256')
+              .update(svcAbiContent)
+              .digest('hex');
+            const abiArchivePath = serviceAbiPath(src.name);
+            entry.abi = {
+              path: abiArchivePath,
+              hash: svcAbiHash,
+              size: svcAbiContent.length,
+            };
+            serviceFilesToWrite.push({
+              relPath: abiArchivePath,
+              content: svcAbiContent,
+            });
+          }
+
+          serviceArtifacts.push(entry);
+          console.log(
+            `   Including service: ${src.name} (${path.basename(svcWasmPath)})`
+          );
+        }
+
         // Build metadata
         const metadata: {
           name: string;
@@ -382,6 +523,7 @@ Note:
             size: wasmSize,
           },
           abi: abiArtifact || undefined,
+          services: serviceArtifacts.length > 0 ? serviceArtifacts : undefined,
           migrations: [],
           links: Object.keys(links).length > 0 ? links : undefined,
           signature: undefined,
@@ -410,12 +552,24 @@ Note:
           fs.writeFileSync(path.join(outputDir, 'abi.json'), abiContent);
         }
 
+        // Copy service files (under services/) preserving their archive paths
+        for (const { relPath, content } of serviceFilesToWrite) {
+          const dest = path.join(outputDir, relPath);
+          fs.mkdirSync(path.dirname(dest), { recursive: true });
+          fs.writeFileSync(dest, content);
+        }
+
         console.log(`✅ Bundle files written to: ${outputDir}`);
         console.log(`   Package: ${finalPackage}`);
         console.log(`   Version: ${finalVersion}`);
         console.log(`   WASM Hash: ${wasmHash}`);
         if (abiArtifact) {
           console.log(`   ABI Hash: ${abiArtifact.hash}`);
+        }
+        if (serviceArtifacts.length > 0) {
+          console.log(
+            `   Services: ${serviceArtifacts.map(s => s.name).join(', ')}`
+          );
         }
         console.log('');
         console.log('Next steps:');
@@ -536,16 +690,40 @@ Note:
             process.exit(1);
           }
           tempMpk = path.join(fullPath, `.temp-push-${Date.now()}.mpk`);
-          const archiveFiles = ['manifest.json', 'app.wasm'];
-          if (fs.existsSync(path.join(fullPath, 'abi.json'))) {
-            archiveFiles.push('abi.json');
+
+          // Derive the file list from the manifest so service WASMs (and any
+          // ABIs) are packed, not just the main app. Falls back to the legacy
+          // app.wasm/abi.json set if the manifest can't be read.
+          let archiveFiles = ['manifest.json', 'app.wasm'];
+          try {
+            const dirManifest = JSON.parse(
+              fs.readFileSync(manifestInDir, 'utf8')
+            ) as BundleManifest;
+            archiveFiles = collectBundleFiles(dirManifest);
+          } catch {
+            if (fs.existsSync(path.join(fullPath, 'abi.json'))) {
+              archiveFiles.push('abi.json');
+            }
           }
+
+          // Verify every referenced file exists before packing.
+          for (const f of archiveFiles) {
+            if (!fs.existsSync(path.join(fullPath, f))) {
+              console.error(
+                `❌ Bundle file referenced by manifest not found: ${f}`
+              );
+              process.exit(1);
+            }
+          }
+
           await tar.create(
             { gzip: true, file: tempMpk, cwd: fullPath },
             archiveFiles
           );
           mpkPath = tempMpk;
-          console.log(`📦 Packed directory into temporary bundle`);
+          console.log(
+            `📦 Packed directory into temporary bundle (${archiveFiles.length} files)`
+          );
         }
 
         console.log(`📦 Processing bundle: ${path.basename(mpkPath)}`);
@@ -891,6 +1069,9 @@ async function pushToRemote(
     }
     if (manifest.abi !== undefined) {
       payload.abi = manifest.abi;
+    }
+    if (manifest.services !== undefined) {
+      payload.services = manifest.services;
     }
     // Always include migrations even if empty — dropping [] changes the signed payload
     payload.migrations = manifest.migrations ?? [];

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -223,6 +223,13 @@ Note:
           console.error('❌ Invalid manifest: "uses" must be an array');
           process.exit(1);
         }
+        if (
+          manifestConfig.services !== undefined &&
+          !Array.isArray(manifestConfig.services)
+        ) {
+          console.error('❌ Invalid manifest: "services" must be an array');
+          process.exit(1);
+        }
 
         // CLI options take precedence - if CLI provides exports/uses, use only those
         const finalExports =
@@ -390,7 +397,20 @@ Note:
         // Relative archive path -> file content, written into outputDir below.
         const serviceFilesToWrite: { relPath: string; content: Buffer }[] = [];
 
-        // Reject duplicate names up front (covers --service + manifest overlap).
+        // Validate every service name BEFORE checking uniqueness, so a bad name
+        // reports a name error rather than a misleading "duplicate" one. CLI
+        // entries were already validated in parseServiceSpec; re-checking is
+        // harmless and also covers manifest entries (which skip that path).
+        for (const { src } of allServiceSources) {
+          try {
+            validateServiceName(src.name);
+          } catch (e) {
+            console.error(`❌ ${e instanceof Error ? e.message : String(e)}`);
+            process.exit(1);
+          }
+        }
+
+        // Then reject duplicate names (covers --service + manifest overlap).
         try {
           assertUniqueServiceNames(allServiceSources.map(s => s.src));
         } catch (e) {
@@ -399,14 +419,6 @@ Note:
         }
 
         for (const { src, baseDir } of allServiceSources) {
-          // Manifest-sourced entries haven't been name-validated yet.
-          try {
-            validateServiceName(src.name);
-          } catch (e) {
-            console.error(`❌ ${e instanceof Error ? e.message : String(e)}`);
-            process.exit(1);
-          }
-
           // Resolve + read the service WASM.
           const svcWasmPath = path.resolve(baseDir, src.wasm);
           if (!fs.existsSync(svcWasmPath)) {
@@ -552,9 +564,19 @@ Note:
           fs.writeFileSync(path.join(outputDir, 'abi.json'), abiContent);
         }
 
-        // Copy service files (under services/) preserving their archive paths
+        // Copy service files (under services/) preserving their archive paths.
+        // Assert each destination stays inside outputDir/services/ — defence in
+        // depth against a crafted name escaping the directory (e.g. "../app"),
+        // independent of validateServiceName.
+        const servicesPrefix = path.join(outputDir, 'services') + path.sep;
         for (const { relPath, content } of serviceFilesToWrite) {
           const dest = path.join(outputDir, relPath);
+          if (!dest.startsWith(servicesPrefix)) {
+            console.error(
+              `❌ Refusing to write service file outside services/: ${relPath}`
+            );
+            process.exit(1);
+          }
           fs.mkdirSync(path.dirname(dest), { recursive: true });
           fs.writeFileSync(dest, content);
         }
@@ -692,18 +714,26 @@ Note:
           tempMpk = path.join(fullPath, `.temp-push-${Date.now()}.mpk`);
 
           // Derive the file list from the manifest so service WASMs (and any
-          // ABIs) are packed, not just the main app. Falls back to the legacy
-          // app.wasm/abi.json set if the manifest can't be read.
-          let archiveFiles = ['manifest.json', 'app.wasm'];
+          // ABIs) are packed, not just the main app. manifest.json is required
+          // and was verified above, so a parse failure is a hard error — never
+          // fall back silently, which would drop service files from the archive
+          // while still reporting success.
+          let archiveFiles: string[];
           try {
             const dirManifest = JSON.parse(
               fs.readFileSync(manifestInDir, 'utf8')
             ) as BundleManifest;
             archiveFiles = collectBundleFiles(dirManifest);
-          } catch {
-            if (fs.existsSync(path.join(fullPath, 'abi.json'))) {
-              archiveFiles.push('abi.json');
-            }
+          } catch (e) {
+            console.error(
+              `❌ Failed to parse manifest.json in ${fullPath}: ${
+                e instanceof Error ? e.message : String(e)
+              }`
+            );
+            console.error(
+              '   Fix the manifest JSON and retry (service files would otherwise be silently omitted).'
+            );
+            process.exit(1);
           }
 
           // Verify every referenced file exists before packing.

--- a/packages/cli/src/lib/local-storage.ts
+++ b/packages/cli/src/lib/local-storage.ts
@@ -52,6 +52,13 @@ export interface BundleSignature {
   signed_at: string;
 }
 
+/** A named service within a multi-service bundle. */
+export interface BundleServiceEntry {
+  name: string;
+  wasm: BundleArtifact;
+  abi?: BundleArtifact;
+}
+
 export interface BundleManifest {
   version: string; // "1.0" (internal manifest version)
   package: string;
@@ -60,8 +67,12 @@ export interface BundleManifest {
   metadata?: BundleMetadata;
   interfaces?: BundleInterfaces;
 
+  /** Single-service WASM (backward compat). Ignored when services is non-empty. */
   wasm?: BundleArtifact;
+  /** Single-service ABI (backward compat). Ignored when services is non-empty. */
   abi?: BundleArtifact;
+  /** Named services for multi-service bundles. */
+  services?: BundleServiceEntry[];
   migrations: BundleArtifact[];
 
   links?: BundleLinks;

--- a/packages/cli/src/lib/local-storage.ts
+++ b/packages/cli/src/lib/local-storage.ts
@@ -52,7 +52,11 @@ export interface BundleSignature {
   signed_at: string;
 }
 
-/** A named service within a multi-service bundle. */
+/**
+ * A named service shipped alongside the main application in a multi-service
+ * bundle (e.g. a "lobby" matchmaking service next to a "tictactoe" main app).
+ * Packed under `services/<name>.wasm` (+ optional `services/<name>.abi.json`).
+ */
 export interface BundleServiceEntry {
   name: string;
   wasm: BundleArtifact;
@@ -67,11 +71,15 @@ export interface BundleManifest {
   metadata?: BundleMetadata;
   interfaces?: BundleInterfaces;
 
-  /** Single-service WASM (backward compat). Ignored when services is non-empty. */
+  /** The MAIN application WASM (packed as `app.wasm`). Always present. */
   wasm?: BundleArtifact;
-  /** Single-service ABI (backward compat). Ignored when services is non-empty. */
+  /** The MAIN application ABI (packed as `abi.json`), if any. */
   abi?: BundleArtifact;
-  /** Named services for multi-service bundles. */
+  /**
+   * Additional named services shipped alongside the main app. Optional and
+   * omitted entirely for single-app bundles, so existing manifests are
+   * unchanged (and their signatures still verify).
+   */
   services?: BundleServiceEntry[];
   migrations: BundleArtifact[];
 

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -34,6 +34,13 @@ export function validateServiceName(name: string): void {
       `Invalid service name "${name}". Use lowercase letters, digits, "-" or "_" (must start alphanumeric).`
     );
   }
+  // Bound the length so it can't blow past filesystem path-component limits
+  // (most systems cap a component at 255 bytes; "<name>.abi.json" adds 9).
+  if (name.length > 64) {
+    throw new Error(
+      `Invalid service name "${name}": must be at most 64 characters.`
+    );
+  }
   if (name === 'app') {
     throw new Error(
       'Service name "app" is reserved for the main application. Choose another name.'
@@ -73,6 +80,14 @@ export function parseServiceSpec(spec: string): ServiceSource {
   const wasm = rest;
   if (!wasm) {
     throw new Error(`Invalid --service "${spec}": missing WASM path.`);
+  }
+  // A comma here means either a comma in the WASM path (unsupported — it would
+  // be silently truncated) or a malformed abi tail (e.g. ",ab=" / ",abi"). Fail
+  // loudly rather than packing the wrong file.
+  if (wasm.includes(',')) {
+    throw new Error(
+      `Invalid --service "${spec}": unexpected comma in WASM path. Use "name=path.wasm,abi=path.json"; commas in paths are not supported.`
+    );
   }
 
   validateServiceName(name);

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -38,7 +38,12 @@ const SERVICE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
  * @throws Error on an invalid name.
  */
 export function validateServiceName(name: string): void {
-  if (!name || !SERVICE_NAME_RE.test(name)) {
+  // Guard the runtime type: `name` is typed string, but it often comes from
+  // parsed manifest JSON, where it could be a number/boolean/etc. Without this,
+  // `RegExp.test(123)` would coerce to "123" and pass, and a numeric 123 would
+  // be treated as distinct from the string "123" by the uniqueness check while
+  // colliding on the same `services/123.wasm` path.
+  if (typeof name !== 'string' || !SERVICE_NAME_RE.test(name)) {
     throw new Error(
       `Invalid service name "${name}". Use lowercase letters, digits, "-" or "_" (must start alphanumeric).`
     );

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -68,7 +68,10 @@ export function parseServiceSpec(spec: string): ServiceSource {
 
   let abi: string | undefined;
   // Optional ",abi=<path>" tail, tolerant of whitespace around the separator.
-  const abiMatch = rest.match(/,\s*abi\s*=\s*(.*)$/);
+  // The abi value may not contain a comma ([^,]*), so a stray second ",abi="
+  // leaves a comma in the WASM path and is caught by the check below. The `*`
+  // (not `+`) still matches an empty value so it reports "empty abi path".
+  const abiMatch = rest.match(/,\s*abi\s*=\s*([^,]*)$/);
   if (abiMatch) {
     abi = abiMatch[1].trim();
     rest = rest.slice(0, abiMatch.index).trim();
@@ -119,10 +122,30 @@ export function assertUniqueServiceNames(services: ServiceSource[]): void {
 }
 
 /**
+ * Reject an archive path that isn't a safe, bundle-relative path. A `.mpk`
+ * unpacked from an untrusted source (or a hand-crafted manifest) could carry a
+ * `path` like `/etc/passwd` or `../../x`; packing such a path would read files
+ * from outside the bundle directory. Paths must be relative and free of any
+ * `..` segment (checked against both separators for cross-platform safety).
+ * @throws Error on an unsafe path.
+ */
+export function assertSafeBundlePath(p: string): void {
+  const segments = p.split(/[\\/]/);
+  if (p.startsWith('/') || /^[a-zA-Z]:/.test(p) || segments.includes('..')) {
+    throw new Error(
+      `Unsafe bundle path "${p}": must be relative and contain no ".." segments.`
+    );
+  }
+}
+
+/**
  * Collect the list of files (relative to the bundle directory) that a manifest
  * references and that must therefore be packed into the `.mpk`. Always includes
  * `manifest.json` and the main `wasm.path`; includes the main `abi.path` and
  * each service's `wasm.path` / `abi.path` when present.
+ *
+ * Every referenced path is checked with {@link assertSafeBundlePath} so a
+ * crafted manifest can't pull files from outside the bundle directory.
  *
  * Used by `bundle push` when packing a directory so service WASMs are not
  * silently dropped from the archive.
@@ -135,6 +158,7 @@ export function collectBundleFiles(manifest: BundleManifest): string[] {
     if (svc.wasm?.path) files.push(svc.wasm.path);
     if (svc.abi?.path) files.push(svc.abi.path);
   }
+  files.forEach(assertSafeBundlePath);
   // De-dupe while preserving order (a malformed manifest could repeat a path).
   return [...new Set(files)];
 }

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -171,6 +171,10 @@ export function assertSafeBundlePath(p: string): void {
  * Every referenced path is checked with {@link assertSafeBundlePath} so a
  * crafted manifest can't pull files from outside the bundle directory.
  *
+ * Throws if a declared service has no `wasm.path` — packing must not silently
+ * drop a service that the manifest advertises. (Callers like `bundle push`
+ * also guard this earlier with a friendlier message.)
+ *
  * Used by `bundle push` when packing a directory so service WASMs are not
  * silently dropped from the archive.
  */
@@ -179,7 +183,12 @@ export function collectBundleFiles(manifest: BundleManifest): string[] {
   if (manifest.wasm?.path) files.push(manifest.wasm.path);
   if (manifest.abi?.path) files.push(manifest.abi.path);
   for (const svc of manifest.services ?? []) {
-    if (svc.wasm?.path) files.push(svc.wasm.path);
+    if (!svc.wasm?.path) {
+      throw new Error(
+        `Service "${svc?.name ?? '<unnamed>'}" has no wasm.path; cannot pack the bundle.`
+      );
+    }
+    files.push(svc.wasm.path);
     if (svc.abi?.path) files.push(svc.abi.path);
   }
   files.forEach(assertSafeBundlePath);

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -20,7 +20,16 @@ export interface ServiceSource {
   abi?: string; // optional path to the service ABI JSON file
 }
 
-/** Service names must be filesystem-safe and collision-free with the main `app.wasm`. */
+/**
+ * Service names must be filesystem-safe and collision-free with the main
+ * `app.wasm`.
+ *
+ * NOTE: this regex and the rules in {@link validateServiceName} (≤64 chars,
+ * not "app") are mirrored backend-side in
+ * packages/backend/src/lib/bundle-storage-kv.js (storeBundleManifest). They are
+ * not shared at the module level (ESM/TS CLI vs CJS backend), so any change
+ * here must be reflected there and vice versa.
+ */
 const SERVICE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
 
 /**
@@ -125,15 +134,25 @@ export function assertUniqueServiceNames(services: ServiceSource[]): void {
  * Reject an archive path that isn't a safe, bundle-relative path. A `.mpk`
  * unpacked from an untrusted source (or a hand-crafted manifest) could carry a
  * `path` like `/etc/passwd` or `../../x`; packing such a path would read files
- * from outside the bundle directory. Paths must be relative and free of any
- * `..` segment (checked against both separators for cross-platform safety).
+ * from outside the bundle directory. Paths must be relative, non-empty, and
+ * free of any `.` or `..` segment (checked against both separators for
+ * cross-platform safety). Our generated paths (`app.wasm`, `abi.json`,
+ * `services/<name>.wasm`) never contain a dot *segment*, so rejecting them is
+ * safe and keeps the guard strict.
  * @throws Error on an unsafe path.
  */
 export function assertSafeBundlePath(p: string): void {
   const segments = p.split(/[\\/]/);
-  if (p.startsWith('/') || /^[a-zA-Z]:/.test(p) || segments.includes('..')) {
+  if (
+    !p ||
+    p.startsWith('/') ||
+    /^[a-zA-Z]:/.test(p) ||
+    segments.includes('..') ||
+    segments.includes('.') ||
+    segments.includes('')
+  ) {
     throw new Error(
-      `Unsafe bundle path "${p}": must be relative and contain no ".." segments.`
+      `Unsafe bundle path "${p}": must be a non-empty relative path with no "." or ".." segments.`
     );
   }
 }

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -122,6 +122,18 @@ export function serviceAbiPath(name: string): string {
 }
 
 /**
+ * True if a service artifact path lives under the `services/` directory (the
+ * layout {@link serviceWasmPath}/{@link serviceAbiPath} emit). Service
+ * artifacts must stay under `services/` so they can't collide with the main
+ * app's top-level `app.wasm` / `abi.json`. Mirrors the backend's
+ * `underServicesDir` (packages/backend/src/lib/bundle-storage-kv.js) — keep the
+ * two in sync.
+ */
+export function isUnderServicesDir(p: string): boolean {
+  return typeof p === 'string' && /^services[\\/]/.test(p);
+}
+
+/**
  * Reject duplicate service names across the merged set (CLI + manifest config).
  * @throws Error listing the first duplicate found.
  */
@@ -183,13 +195,29 @@ export function collectBundleFiles(manifest: BundleManifest): string[] {
   if (manifest.wasm?.path) files.push(manifest.wasm.path);
   if (manifest.abi?.path) files.push(manifest.abi.path);
   for (const svc of manifest.services ?? []) {
+    const label = svc?.name ?? '<unnamed>';
     if (!svc.wasm?.path) {
       throw new Error(
-        `Service "${svc?.name ?? '<unnamed>'}" has no wasm.path; cannot pack the bundle.`
+        `Service "${label}" has no wasm.path; cannot pack the bundle.`
+      );
+    }
+    // Service artifacts must live under services/ (matches the backend's
+    // storeBundleManifest check), so packing fails fast locally instead of
+    // succeeding here and being rejected by the registry after upload.
+    if (!isUnderServicesDir(svc.wasm.path)) {
+      throw new Error(
+        `Service "${label}" wasm.path "${svc.wasm.path}" must be under services/.`
       );
     }
     files.push(svc.wasm.path);
-    if (svc.abi?.path) files.push(svc.abi.path);
+    if (svc.abi?.path) {
+      if (!isUnderServicesDir(svc.abi.path)) {
+        throw new Error(
+          `Service "${label}" abi.path "${svc.abi.path}" must be under services/.`
+        );
+      }
+      files.push(svc.abi.path);
+    }
   }
   files.forEach(assertSafeBundlePath);
   // De-dupe while preserving order (a malformed manifest could repeat a path).

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -1,0 +1,125 @@
+/**
+ * Multi-service bundle helpers.
+ *
+ * A bundle always has a MAIN application (manifest.wasm / manifest.abi, packed
+ * as `app.wasm` / `abi.json`). A multi-service bundle additionally ships one or
+ * more named SERVICE WASMs alongside the main app — e.g. a "tictactoe" main app
+ * with a "lobby" matchmaking service. Service artifacts are packed under
+ * `services/<name>.wasm` (+ optional `services/<name>.abi.json`).
+ *
+ * These helpers are pure (no I/O) so they can be unit-tested in isolation; the
+ * `bundle` command wires them to the filesystem.
+ */
+
+import type { BundleManifest } from './local-storage.js';
+
+/** Source-file references for a service, as authored on the CLI or in a manifest config file. */
+export interface ServiceSource {
+  name: string;
+  wasm: string; // path to the service WASM file
+  abi?: string; // optional path to the service ABI JSON file
+}
+
+/** Service names must be filesystem-safe and collision-free with the main `app.wasm`. */
+const SERVICE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+/**
+ * Validate a service name. Names become path segments (`services/<name>.wasm`),
+ * so they must be lowercase, free of separators, and not the reserved main name.
+ * @throws Error on an invalid name.
+ */
+export function validateServiceName(name: string): void {
+  if (!name || !SERVICE_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid service name "${name}". Use lowercase letters, digits, "-" or "_" (must start alphanumeric).`
+    );
+  }
+  if (name === 'app') {
+    throw new Error(
+      'Service name "app" is reserved for the main application. Choose another name.'
+    );
+  }
+}
+
+/**
+ * Parse a `--service` CLI spec of the form:
+ *   `name=path/to.wasm`
+ *   `name=path/to.wasm,abi=path/to-abi.json`
+ *
+ * The ABI segment is optional. Whitespace around tokens is trimmed.
+ * @throws Error on a malformed spec.
+ */
+export function parseServiceSpec(spec: string): ServiceSource {
+  const eq = spec.indexOf('=');
+  if (eq === -1) {
+    throw new Error(
+      `Invalid --service "${spec}". Expected "name=path.wasm" or "name=path.wasm,abi=path.json".`
+    );
+  }
+  const name = spec.slice(0, eq).trim();
+  let rest = spec.slice(eq + 1).trim();
+
+  let abi: string | undefined;
+  // Optional ",abi=<path>" tail, tolerant of whitespace around the separator.
+  const abiMatch = rest.match(/,\s*abi\s*=\s*(.*)$/);
+  if (abiMatch) {
+    abi = abiMatch[1].trim();
+    rest = rest.slice(0, abiMatch.index).trim();
+    if (!abi) {
+      throw new Error(`Invalid --service "${spec}": empty abi path.`);
+    }
+  }
+
+  const wasm = rest;
+  if (!wasm) {
+    throw new Error(`Invalid --service "${spec}": missing WASM path.`);
+  }
+
+  validateServiceName(name);
+  return abi ? { name, wasm, abi } : { name, wasm };
+}
+
+/** The in-bundle artifact path for a service's WASM (e.g. "services/lobby.wasm"). */
+export function serviceWasmPath(name: string): string {
+  return `services/${name}.wasm`;
+}
+
+/** The in-bundle artifact path for a service's ABI (e.g. "services/lobby.abi.json"). */
+export function serviceAbiPath(name: string): string {
+  return `services/${name}.abi.json`;
+}
+
+/**
+ * Reject duplicate service names across the merged set (CLI + manifest config).
+ * @throws Error listing the first duplicate found.
+ */
+export function assertUniqueServiceNames(services: ServiceSource[]): void {
+  const seen = new Set<string>();
+  for (const s of services) {
+    if (seen.has(s.name)) {
+      throw new Error(`Duplicate service name "${s.name}".`);
+    }
+    seen.add(s.name);
+  }
+}
+
+/**
+ * Collect the list of files (relative to the bundle directory) that a manifest
+ * references and that must therefore be packed into the `.mpk`. Always includes
+ * `manifest.json` and the main `wasm.path`; includes the main `abi.path` and
+ * each service's `wasm.path` / `abi.path` when present.
+ *
+ * Used by `bundle push` when packing a directory so service WASMs are not
+ * silently dropped from the archive.
+ */
+export function collectBundleFiles(manifest: BundleManifest): string[] {
+  const files = ['manifest.json'];
+  if (manifest.wasm?.path) files.push(manifest.wasm.path);
+  if (manifest.abi?.path) files.push(manifest.abi.path);
+  for (const svc of manifest.services ?? []) {
+    if (svc.wasm?.path) files.push(svc.wasm.path);
+    if (svc.abi?.path) files.push(svc.abi.path);
+  }
+  // De-dupe while preserving order (a malformed manifest could repeat a path).
+  return [...new Set(files)];
+}

--- a/packages/cli/src/test/services.test.ts
+++ b/packages/cli/src/test/services.test.ts
@@ -215,4 +215,14 @@ describe('assertSafeBundlePath', () => {
       /Unsafe bundle path/
     );
   });
+
+  it('rejects "." segments and empty segments', () => {
+    expect(() => assertSafeBundlePath('services/./x.wasm')).toThrow(
+      /Unsafe bundle path/
+    );
+    expect(() => assertSafeBundlePath('services//x.wasm')).toThrow(
+      /Unsafe bundle path/
+    );
+    expect(() => assertSafeBundlePath('')).toThrow(/Unsafe bundle path/);
+  });
 });

--- a/packages/cli/src/test/services.test.ts
+++ b/packages/cli/src/test/services.test.ts
@@ -57,6 +57,12 @@ describe('parseServiceSpec', () => {
       /Invalid service name/
     );
   });
+
+  it('rejects a comma in the WASM path rather than truncating it', () => {
+    expect(() => parseServiceSpec('lobby=path/to,file.wasm')).toThrow(
+      /unexpected comma in WASM path/
+    );
+  });
 });
 
 describe('validateServiceName', () => {
@@ -70,6 +76,13 @@ describe('validateServiceName', () => {
     expect(() => validateServiceName('Lobby')).toThrow();
     expect(() => validateServiceName('-lobby')).toThrow();
     expect(() => validateServiceName('app')).toThrow(/reserved/);
+  });
+
+  it('rejects a name longer than 64 characters', () => {
+    expect(() => validateServiceName('a'.repeat(65))).toThrow(
+      /at most 64 characters/
+    );
+    expect(() => validateServiceName('a'.repeat(64))).not.toThrow();
   });
 });
 

--- a/packages/cli/src/test/services.test.ts
+++ b/packages/cli/src/test/services.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseServiceSpec,
+  validateServiceName,
+  serviceWasmPath,
+  serviceAbiPath,
+  assertUniqueServiceNames,
+  collectBundleFiles,
+} from '../lib/services.js';
+import type { BundleManifest } from '../lib/local-storage.js';
+
+describe('parseServiceSpec', () => {
+  it('parses name and wasm path', () => {
+    expect(parseServiceSpec('lobby=lobby.wasm')).toEqual({
+      name: 'lobby',
+      wasm: 'lobby.wasm',
+    });
+  });
+
+  it('parses name, wasm and abi', () => {
+    expect(
+      parseServiceSpec('lobby=res/lobby.wasm,abi=res/lobby-abi.json')
+    ).toEqual({
+      name: 'lobby',
+      wasm: 'res/lobby.wasm',
+      abi: 'res/lobby-abi.json',
+    });
+  });
+
+  it('trims whitespace around tokens', () => {
+    expect(parseServiceSpec(' lobby = lobby.wasm , abi = abi.json ')).toEqual({
+      name: 'lobby',
+      wasm: 'lobby.wasm',
+      abi: 'abi.json',
+    });
+  });
+
+  it('throws when there is no "="', () => {
+    expect(() => parseServiceSpec('lobby.wasm')).toThrow(/Expected "name=path/);
+  });
+
+  it('throws on missing wasm path', () => {
+    expect(() => parseServiceSpec('lobby=')).toThrow(/missing WASM path/);
+  });
+
+  it('throws on empty abi path', () => {
+    expect(() => parseServiceSpec('lobby=lobby.wasm,abi=')).toThrow(
+      /empty abi path/
+    );
+  });
+
+  it('rejects an invalid service name', () => {
+    expect(() => parseServiceSpec('Lobby=lobby.wasm')).toThrow(
+      /Invalid service name/
+    );
+    expect(() => parseServiceSpec('foo/bar=lobby.wasm')).toThrow(
+      /Invalid service name/
+    );
+  });
+});
+
+describe('validateServiceName', () => {
+  it('accepts lowercase alphanumeric with - and _', () => {
+    expect(() => validateServiceName('lobby')).not.toThrow();
+    expect(() => validateServiceName('match-maker_2')).not.toThrow();
+  });
+
+  it('rejects empty, uppercase, leading-symbol and reserved "app"', () => {
+    expect(() => validateServiceName('')).toThrow();
+    expect(() => validateServiceName('Lobby')).toThrow();
+    expect(() => validateServiceName('-lobby')).toThrow();
+    expect(() => validateServiceName('app')).toThrow(/reserved/);
+  });
+});
+
+describe('artifact path helpers', () => {
+  it('builds service wasm/abi paths under services/', () => {
+    expect(serviceWasmPath('lobby')).toBe('services/lobby.wasm');
+    expect(serviceAbiPath('lobby')).toBe('services/lobby.abi.json');
+  });
+});
+
+describe('assertUniqueServiceNames', () => {
+  it('passes for unique names', () => {
+    expect(() =>
+      assertUniqueServiceNames([
+        { name: 'lobby', wasm: 'a.wasm' },
+        { name: 'chat', wasm: 'b.wasm' },
+      ])
+    ).not.toThrow();
+  });
+
+  it('throws on a duplicate name', () => {
+    expect(() =>
+      assertUniqueServiceNames([
+        { name: 'lobby', wasm: 'a.wasm' },
+        { name: 'lobby', wasm: 'b.wasm' },
+      ])
+    ).toThrow(/Duplicate service name "lobby"/);
+  });
+});
+
+describe('collectBundleFiles', () => {
+  const base: BundleManifest = {
+    version: '1.0',
+    package: 'com.calimero.ttt',
+    appVersion: '1.0.0',
+    wasm: { path: 'app.wasm', hash: 'h', size: 1 },
+    migrations: [],
+  };
+
+  it('returns manifest + main wasm for a single-app bundle (backward compat)', () => {
+    expect(collectBundleFiles(base)).toEqual(['manifest.json', 'app.wasm']);
+  });
+
+  it('includes the main abi when present', () => {
+    const m = { ...base, abi: { path: 'abi.json', hash: 'h', size: 2 } };
+    expect(collectBundleFiles(m)).toEqual([
+      'manifest.json',
+      'app.wasm',
+      'abi.json',
+    ]);
+  });
+
+  it('includes service wasm and abi files', () => {
+    const m: BundleManifest = {
+      ...base,
+      abi: { path: 'abi.json', hash: 'h', size: 2 },
+      services: [
+        {
+          name: 'lobby',
+          wasm: { path: 'services/lobby.wasm', hash: 'h', size: 3 },
+          abi: { path: 'services/lobby.abi.json', hash: 'h', size: 4 },
+        },
+        {
+          name: 'chat',
+          wasm: { path: 'services/chat.wasm', hash: 'h', size: 5 },
+        },
+      ],
+    };
+    expect(collectBundleFiles(m)).toEqual([
+      'manifest.json',
+      'app.wasm',
+      'abi.json',
+      'services/lobby.wasm',
+      'services/lobby.abi.json',
+      'services/chat.wasm',
+    ]);
+  });
+
+  it('de-dupes repeated paths', () => {
+    const m: BundleManifest = {
+      ...base,
+      services: [
+        {
+          name: 'dup',
+          wasm: { path: 'app.wasm', hash: 'h', size: 1 },
+        },
+      ],
+    };
+    expect(collectBundleFiles(m)).toEqual(['manifest.json', 'app.wasm']);
+  });
+});

--- a/packages/cli/src/test/services.test.ts
+++ b/packages/cli/src/test/services.test.ts
@@ -5,6 +5,7 @@ import {
   serviceWasmPath,
   serviceAbiPath,
   assertUniqueServiceNames,
+  assertSafeBundlePath,
   collectBundleFiles,
 } from '../lib/services.js';
 import type { BundleManifest } from '../lib/local-storage.js';
@@ -172,5 +173,46 @@ describe('collectBundleFiles', () => {
       ],
     };
     expect(collectBundleFiles(m)).toEqual(['manifest.json', 'app.wasm']);
+  });
+
+  it('rejects a service path that escapes the bundle directory', () => {
+    const m: BundleManifest = {
+      ...base,
+      services: [
+        {
+          name: 'evil',
+          wasm: { path: '../../etc/passwd', hash: 'h', size: 1 },
+        },
+      ],
+    };
+    expect(() => collectBundleFiles(m)).toThrow(/Unsafe bundle path/);
+  });
+});
+
+describe('assertSafeBundlePath', () => {
+  it('accepts safe relative paths', () => {
+    expect(() => assertSafeBundlePath('app.wasm')).not.toThrow();
+    expect(() => assertSafeBundlePath('services/lobby.wasm')).not.toThrow();
+  });
+
+  it('rejects absolute paths', () => {
+    expect(() => assertSafeBundlePath('/etc/passwd')).toThrow(
+      /Unsafe bundle path/
+    );
+    expect(() => assertSafeBundlePath('C:\\Windows\\x')).toThrow(
+      /Unsafe bundle path/
+    );
+  });
+
+  it('rejects ".." traversal with either separator', () => {
+    expect(() => assertSafeBundlePath('../app.wasm')).toThrow(
+      /Unsafe bundle path/
+    );
+    expect(() => assertSafeBundlePath('services/../../app.wasm')).toThrow(
+      /Unsafe bundle path/
+    );
+    expect(() => assertSafeBundlePath('services\\..\\app.wasm')).toThrow(
+      /Unsafe bundle path/
+    );
   });
 });

--- a/packages/cli/src/test/services.test.ts
+++ b/packages/cli/src/test/services.test.ts
@@ -4,6 +4,7 @@ import {
   validateServiceName,
   serviceWasmPath,
   serviceAbiPath,
+  isUnderServicesDir,
   assertUniqueServiceNames,
   assertSafeBundlePath,
   collectBundleFiles,
@@ -102,6 +103,13 @@ describe('artifact path helpers', () => {
     expect(serviceWasmPath('lobby')).toBe('services/lobby.wasm');
     expect(serviceAbiPath('lobby')).toBe('services/lobby.abi.json');
   });
+
+  it('isUnderServicesDir accepts services/ paths and rejects top-level ones', () => {
+    expect(isUnderServicesDir('services/lobby.wasm')).toBe(true);
+    expect(isUnderServicesDir('app.wasm')).toBe(false);
+    expect(isUnderServicesDir('abi.json')).toBe(false);
+    expect(isUnderServicesDir('servicesX/lobby.wasm')).toBe(false);
+  });
 });
 
 describe('assertUniqueServiceNames', () => {
@@ -172,19 +180,6 @@ describe('collectBundleFiles', () => {
     ]);
   });
 
-  it('de-dupes repeated paths', () => {
-    const m: BundleManifest = {
-      ...base,
-      services: [
-        {
-          name: 'dup',
-          wasm: { path: 'app.wasm', hash: 'h', size: 1 },
-        },
-      ],
-    };
-    expect(collectBundleFiles(m)).toEqual(['manifest.json', 'app.wasm']);
-  });
-
   it('throws when a declared service has no wasm.path', () => {
     const m = {
       ...base,
@@ -193,13 +188,25 @@ describe('collectBundleFiles', () => {
     expect(() => collectBundleFiles(m)).toThrow(/has no wasm.path/);
   });
 
+  it('rejects a service whose wasm.path is not under services/', () => {
+    const m: BundleManifest = {
+      ...base,
+      services: [
+        // Would collide with the main app's app.wasm on unpack.
+        { name: 'dup', wasm: { path: 'app.wasm', hash: 'h', size: 1 } },
+      ],
+    };
+    expect(() => collectBundleFiles(m)).toThrow(/must be under services\//);
+  });
+
   it('rejects a service path that escapes the bundle directory', () => {
     const m: BundleManifest = {
       ...base,
       services: [
         {
           name: 'evil',
-          wasm: { path: '../../etc/passwd', hash: 'h', size: 1 },
+          // Under services/ (passes that check) but still traverses out.
+          wasm: { path: 'services/../../etc/passwd', hash: 'h', size: 1 },
         },
       ],
     };

--- a/packages/cli/src/test/services.test.ts
+++ b/packages/cli/src/test/services.test.ts
@@ -85,6 +85,16 @@ describe('validateServiceName', () => {
     );
     expect(() => validateServiceName('a'.repeat(64))).not.toThrow();
   });
+
+  it('rejects non-string names (e.g. a number from manifest JSON)', () => {
+    // Manifest JSON can violate the `string` type at runtime.
+    expect(() => validateServiceName(123 as unknown as string)).toThrow(
+      /Invalid service name/
+    );
+    expect(() => validateServiceName(null as unknown as string)).toThrow(
+      /Invalid service name/
+    );
+  });
 });
 
 describe('artifact path helpers', () => {

--- a/packages/cli/src/test/services.test.ts
+++ b/packages/cli/src/test/services.test.ts
@@ -185,6 +185,14 @@ describe('collectBundleFiles', () => {
     expect(collectBundleFiles(m)).toEqual(['manifest.json', 'app.wasm']);
   });
 
+  it('throws when a declared service has no wasm.path', () => {
+    const m = {
+      ...base,
+      services: [{ name: 'lobby' }],
+    } as unknown as BundleManifest;
+    expect(() => collectBundleFiles(m)).toThrow(/has no wasm.path/);
+  });
+
   it('rejects a service path that escapes the bundle directory', () => {
     const m: BundleManifest = {
       ...base,


### PR DESCRIPTION
# feat: multi-service bundles (main app + services)

## What this PR does

Lets a single bundle ship a **main application plus one or more named services** — e.g. a `tictactoe` main app bundled with a `lobby` matchmaking service — and wires that concept through the **entire bundle lifecycle** (build → pack → push → store → fetch), not just the type system.

## Background: how bundles worked before

A bundle (`.mpk`) packaged exactly **one** WASM:

- `bundle create` hashed a single `app.wasm` (+ optional `abi.json`) and wrote a `manifest.json` with a single `wasm` / `abi` artifact.
- `bundle push` tarred `manifest.json` + `app.wasm` (+ `abi.json`), the backend verified the manifest's ed25519 signature, and stored the manifest + blob.
- There was no way to ship more than one WASM in a bundle.

## What changed

The first commit on this branch only added the **types** (`BundleServiceEntry`, an optional `services?` array) to `BundleManifest`. Nothing read them — no builder, packer, push payload, backend, or OpenAPI support. This PR makes them real.

### Model: main + extras (not either/or)

The main app stays where it always was — `manifest.wasm` / `manifest.abi`, packed as `app.wasm` / `abi.json`. Services are **additional** named WASMs packed under `services/<name>.wasm` (+ optional `services/<name>.abi.json`):

```jsonc
{
  "package": "com.calimero.ttt",
  "appVersion": "1.0.0",
  "wasm": { "path": "app.wasm", "hash": "…", "size": … },        // MAIN app (tictactoe)
  "abi":  { "path": "abi.json", "hash": "…", "size": … },
  "services": [                                                   // extras
    {
      "name": "lobby",
      "wasm": { "path": "services/lobby.wasm", "hash": "…", "size": … },
      "abi":  { "path": "services/lobby.abi.json", "hash": "…", "size": … }
    }
  ],
  "migrations": []
}
```

### CLI (`packages/cli`)

- **`bundle create`** accepts services two ways:
  - repeatable flag: `--service lobby=lobby.wasm,abi=lobby-abi.json`
  - manifest config: a `"services": [{ "name", "wasm", "abi" }]` array (paths relative to the manifest file)
  - Each service WASM/ABI is hashed and copied into `services/`; names must be valid and unique.
- **`bundle push`** now derives the pack-list **from the manifest** (`collectBundleFiles`), so service WASMs/ABIs are included in the `.mpk` — not just `app.wasm`.
- New `packages/cli/src/lib/services.ts` holds the pure, unit-tested helpers (spec parsing, name validation, artifact paths, file collection).

### Backend (`packages/backend`)

- `storeBundleManifest` validates the `services` structure (array, named, unique, each with a `wasm` object) before writing, then carries it through store/fetch wholesale.
- `api.yml`: `BundleManifest` gains `abi` + `services`; added `BundleArtifact` and `BundleServiceEntry` schemas.

## What we support now

| Capability | Before | After |
| --- | --- | --- |
| Single-app bundle (`app.wasm` + `abi.json`) | ✅ | ✅ (unchanged) |
| Main app **+ N named services** in one bundle | ❌ | ✅ |
| Per-service WASM **and** optional per-service ABI | ❌ | ✅ |
| Services via CLI flag and/or manifest file | ❌ | ✅ |
| Service files packed into the `.mpk` and stored | ❌ | ✅ |
| Manifest signature covers service hashes | n/a | ✅ (automatic) |

## Backwards compatibility

`services` is **optional and omitted entirely** for single-app bundles, so:

- Existing manifests are byte-identical → their **ed25519 signatures still verify** unchanged. The signer/verifier canonicalize the whole manifest, so when `services` *is* present each service's hash is signed automatically — **no change to `verify.js`**.
- Existing `bundle create` / `push` invocations behave exactly as before (a no-service bundle still packs `manifest.json` + `app.wasm` only).
- Backend store/fetch is wholesale, so old and new manifests round-trip without migration.

## Hardening (from review)

Non-array `services` config is rejected; service names are validated (charset, ≤64 chars, not the reserved `app`) **before** the uniqueness check so errors are accurate; comma-in-WASM-path is rejected instead of truncated; service-file writes are asserted to stay under `services/` (path-traversal defence); `push` hard-errors on an unparseable `manifest.json` instead of silently dropping service files; backend rejects array-valued `service.wasm`.

## Tests

- **CLI** (`services.test.ts`): 18 unit tests — spec parsing, name/length/charset validation, comma rejection, artifact paths, uniqueness, `collectBundleFiles` (incl. backward-compat + de-dup).
- **Backend** (`multi-service-bundle.test.js`): services round-trip intact, single-app bundle unaffected, and rejection of non-array / nameless / wasm-less / array-wasm / duplicate-name services.
- Full suites green (CLI 52, backend 65); lint + prettier clean. Verified end-to-end with the built CLI: a multi-service bundle round-trips `services`, packs the `services/` files into the `.mpk`, and a single-app bundle is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches manifest shape, packing, and authoritative registry validation (including path-safety rules duplicated between CLI and backend); mistakes could reject valid uploads or accept unsafe manifests if rules drift.
> 
> **Overview**
> Bundles can now ship a **main app** (`app.wasm` / `abi.json`) plus optional **named services** under `services/<name>.wasm` (and optional per-service ABIs), wired through build, pack, push, and registry storage.
> 
> **CLI:** `bundle create` accepts repeatable `--service name=wasm[,abi=…]` and manifest `services` entries; hashes and copies artifacts into the bundle layout. `bundle push` builds the `.mpk` file list from the manifest via `collectBundleFiles` (so service files are included), forwards `services` on upload, and fails on bad manifests instead of omitting service files.
> 
> **Backend & API:** OpenAPI adds `BundleArtifact`, `BundleServiceEntry`, and optional `services` on `BundleManifest`. `storeBundleManifest` validates service names, uniqueness, required `wasm`, and safe `services/` paths before any KV write.
> 
> **Compatibility:** Omitting `services` keeps single-app bundles unchanged. **Hardening** mirrors CLI rules server-side and blocks path traversal / `app.wasm` collisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a624a395494e99864b9ad03f029d3909b69982e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->