### PR TITLE
feat(api): add all_versions query param to bundle listing

### DIFF
--- a/api/lib/auth-helpers.js
+++ b/api/lib/auth-helpers.js
@@ -154,10 +154,24 @@ async function requireAdmin(req, res) {
   return user;
 }
 
+/**
+ * Check whether a bundle manifest is owned by the given session user.
+ * Ownership is determined by metadata.author (username) or metadata._ownerEmail.
+ */
+function manifestOwnedByUser(manifest, user) {
+  const author = manifest?.metadata?.author;
+  const ownerEmail = manifest?.metadata?._ownerEmail;
+  if (user?.username && author === user.username) return true;
+  if (user?.email && ownerEmail === user.email) return true;
+  if (user?.email && !user?.username && author === user.email) return true;
+  return false;
+}
+
 module.exports = {
   resolveUser,
   requireAuth,
   requireOrgAdminOrOwner,
   requireOrgOwner,
   requireAdmin,
+  manifestOwnedByUser,
 };

--- a/api/v2/bundles/[package]/[version].js
+++ b/api/v2/bundles/[package]/[version].js
@@ -16,6 +16,7 @@ const {
   isAllowedOwner,
 } = require('../../../lib/verify');
 const { requireAuth } = require('../../../lib/auth-helpers');
+const { kv } = require('../../../lib/kv-client');
 
 let storage;
 function getStorage() {
@@ -229,6 +230,8 @@ module.exports = async function handler(req, res) {
 
     try {
       await store.deleteBundleVersion(pkg, version);
+      // Clean up yank flag so a future re-publish of the same semver starts fresh.
+      await kv.del(`bundle-yanked:${pkg}/${version}`).catch(() => {});
       return res.status(200).json({ message: `Deleted ${pkg}@${version}` });
     } catch (error) {
       console.error('DELETE version error:', error);

--- a/api/v2/bundles/[package]/[version]/yank.js
+++ b/api/v2/bundles/[package]/[version]/yank.js
@@ -19,7 +19,8 @@ const { kv } = require('../../../../lib/kv-client');
 
 // Scoped packages (@org/name) are allowed; bare path traversal sequences are not.
 const PKG_RE = /^(?:@[\w.-]+\/)?[\w.+-]+$/;
-const VER_RE = /^[\w.+-]+$/;
+// Block repeated dots (e.g. `..`) in addition to the character allowlist.
+const VER_RE = /^(?!.*\.{2})[\w.+-]+$/;
 
 let _store;
 function getStorage() {
@@ -45,6 +46,9 @@ module.exports = async function handler(req, res) {
     });
   }
 
+  const user = await requireAuth(req, res);
+  if (!user) return;
+
   const body = req.body || {};
   if (typeof body.yanked !== 'boolean') {
     return res.status(400).json({
@@ -52,9 +56,6 @@ module.exports = async function handler(req, res) {
       message: '`yanked` must be a boolean',
     });
   }
-
-  const user = await requireAuth(req, res);
-  if (!user) return;
 
   const store = getStorage();
   let existing;

--- a/api/v2/bundles/[package]/[version]/yank.js
+++ b/api/v2/bundles/[package]/[version]/yank.js
@@ -1,0 +1,123 @@
+/**
+ * V2 Bundle Yank API
+ * POST /api/v2/bundles/:package/:version/yank  { yanked: true }   — mark unsupported
+ * POST /api/v2/bundles/:package/:version/yank  { yanked: false }  — restore
+ *
+ * Only the package owner (same pubkey or session user) can yank/unyank.
+ * Yanked versions are hidden from the version picker but the bundle manifest
+ * remains accessible at GET /api/v2/bundles/:package/:version so existing
+ * installs are not broken.
+ */
+
+const {
+  BundleStorageKV,
+} = require('@calimero-network/registry-backend/src/lib/bundle-storage-kv');
+const {
+  getPublicKeyFromManifest,
+  isAllowedOwner,
+} = require('../../../../lib/verify');
+const { requireAuth } = require('../../../../lib/auth-helpers');
+
+let storage;
+function getStorage() {
+  if (!storage) storage = new BundleStorageKV();
+  return storage;
+}
+
+let kvClient;
+async function getKV() {
+  if (kvClient) return kvClient;
+
+  const isProduction = process.env.VERCEL === '1' || !!process.env.REDIS_URL;
+  if (isProduction && process.env.REDIS_URL) {
+    const { createClient } = require('redis');
+    const redisClient = createClient({ url: process.env.REDIS_URL });
+    redisClient.on('error', err => console.error('Redis error:', err));
+
+    kvClient = {
+      _connected: false,
+      _connecting: null,
+      async _ensureConnected() {
+        if (this._connected) return;
+        if (this._connecting) { await this._connecting; return; }
+        this._connecting = redisClient.connect()
+          .then(() => { this._connected = true; this._connecting = null; })
+          .catch(err => { this._connected = false; this._connecting = null; throw err; });
+        await this._connecting;
+      },
+      async get(key) { await this._ensureConnected(); return redisClient.get(key); },
+      async set(key, value) { await this._ensureConnected(); return redisClient.set(key, value); },
+      async del(key) { await this._ensureConnected(); return redisClient.del(key); },
+    };
+    return kvClient;
+  }
+
+  const mockStore = new Map();
+  kvClient = {
+    async get(key) { return mockStore.get(key) ?? null; },
+    async set(key, value) { mockStore.set(key, value); },
+    async del(key) { mockStore.delete(key); },
+  };
+  return kvClient;
+}
+
+function manifestOwnedByUser(manifest, user) {
+  const author = manifest?.metadata?.author;
+  const ownerEmail = manifest?.metadata?._ownerEmail;
+  if (user?.username && author === user.username) return true;
+  if (user?.email && ownerEmail === user.email) return true;
+  if (user?.email && !user?.username && author === user.email) return true;
+  return false;
+}
+
+module.exports = async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const { package: pkg, version } = req.query;
+  if (!pkg || !version) return res.status(400).json({ error: 'missing_params' });
+
+  const body = req.body || {};
+  if (typeof body.yanked !== 'boolean') {
+    return res.status(400).json({ error: 'invalid_body', message: '`yanked` must be a boolean' });
+  }
+
+  // Require authenticated user
+  const user = await requireAuth(req, res);
+  if (!user) return; // requireAuth sends the 401 itself
+
+  const store = getStorage();
+  let existing;
+  try {
+    existing = await store.getBundleManifest(pkg, version);
+  } catch (e) {
+    return res.status(500).json({ error: 'internal_error', message: e?.message ?? String(e) });
+  }
+  if (!existing) return res.status(404).json({ error: 'not_found' });
+
+  // Allow if session user owns the package OR the request carries a valid owner pubkey
+  const sigKey = body.signature ? getPublicKeyFromManifest(body) : null;
+  const ownedBySig = sigKey && isAllowedOwner(existing, sigKey);
+  const ownedBySession = manifestOwnedByUser(existing, user);
+
+  if (!ownedBySig && !ownedBySession) {
+    return res.status(403).json({ error: 'not_owner', message: 'Only the package owner can yank this version.' });
+  }
+
+  const kv = await getKV();
+  const yankKey = `bundle-yanked:${pkg}/${version}`;
+
+  try {
+    if (body.yanked) {
+      await kv.set(yankKey, '1');
+    } else {
+      await kv.del(yankKey);
+    }
+    return res.status(200).json({ package: pkg, version, yanked: body.yanked });
+  } catch (e) {
+    return res.status(500).json({ error: 'internal_error', message: e?.message ?? String(e) });
+  }
+};

--- a/api/v2/bundles/[package]/[version]/yank.js
+++ b/api/v2/bundles/[package]/[version]/yank.js
@@ -19,8 +19,8 @@ const { kv } = require('../../../../lib/kv-client');
 
 // Scoped packages (@org/name) are allowed; bare path traversal sequences are not.
 const PKG_RE = /^(?:@[\w.-]+\/)?[\w.+-]+$/;
-// Block repeated dots (e.g. `..`) in addition to the character allowlist.
-const VER_RE = /^(?!.*\.{2})[\w.+-]+$/;
+// Must start with a word char; block consecutive dots; allow semver + pre-release/build.
+const VER_RE = /^\w(?!.*\.{2})[\w.+-]*$/;
 
 let _store;
 function getStorage() {

--- a/api/v2/bundles/[package]/[version]/yank.js
+++ b/api/v2/bundles/[package]/[version]/yank.js
@@ -3,62 +3,24 @@
  * POST /api/v2/bundles/:package/:version/yank  { yanked: true }   — mark unsupported
  * POST /api/v2/bundles/:package/:version/yank  { yanked: false }  — restore
  *
- * Only the package owner (same pubkey or session user) can yank/unyank.
- * Yanked versions are hidden from the version picker but the bundle manifest
- * remains accessible at GET /api/v2/bundles/:package/:version so existing
- * installs are not broken.
+ * Only the package owner (session user) can yank/unyank.
+ * Yanked versions remain accessible at GET /api/v2/bundles/:package/:version
+ * so existing installs are not broken.
  */
 
 const {
   BundleStorageKV,
 } = require('@calimero-network/registry-backend/src/lib/bundle-storage-kv');
-const {
-  getPublicKeyFromManifest,
-  isAllowedOwner,
-} = require('../../../../lib/verify');
 const { requireAuth } = require('../../../../lib/auth-helpers');
+const { kv } = require('../../../../lib/kv-client');
 
-let storage;
+const PKG_RE = /^[\w.@/-]+$/;
+const VER_RE = /^[\w.+-]+$/;
+
+let _store;
 function getStorage() {
-  if (!storage) storage = new BundleStorageKV();
-  return storage;
-}
-
-let kvClient;
-async function getKV() {
-  if (kvClient) return kvClient;
-
-  const isProduction = process.env.VERCEL === '1' || !!process.env.REDIS_URL;
-  if (isProduction && process.env.REDIS_URL) {
-    const { createClient } = require('redis');
-    const redisClient = createClient({ url: process.env.REDIS_URL });
-    redisClient.on('error', err => console.error('Redis error:', err));
-
-    kvClient = {
-      _connected: false,
-      _connecting: null,
-      async _ensureConnected() {
-        if (this._connected) return;
-        if (this._connecting) { await this._connecting; return; }
-        this._connecting = redisClient.connect()
-          .then(() => { this._connected = true; this._connecting = null; })
-          .catch(err => { this._connected = false; this._connecting = null; throw err; });
-        await this._connecting;
-      },
-      async get(key) { await this._ensureConnected(); return redisClient.get(key); },
-      async set(key, value) { await this._ensureConnected(); return redisClient.set(key, value); },
-      async del(key) { await this._ensureConnected(); return redisClient.del(key); },
-    };
-    return kvClient;
-  }
-
-  const mockStore = new Map();
-  kvClient = {
-    async get(key) { return mockStore.get(key) ?? null; },
-    async set(key, value) { mockStore.set(key, value); },
-    async del(key) { mockStore.delete(key); },
-  };
-  return kvClient;
+  if (!_store) _store = new BundleStorageKV();
+  return _store;
 }
 
 function manifestOwnedByUser(manifest, user) {
@@ -75,39 +37,48 @@ module.exports = async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   if (req.method === 'OPTIONS') return res.status(200).end();
-  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+  if (req.method !== 'POST')
+    return res.status(405).json({ error: 'Method not allowed' });
 
   const { package: pkg, version } = req.query;
-  if (!pkg || !version) return res.status(400).json({ error: 'missing_params' });
+  if (!pkg || !version)
+    return res.status(400).json({ error: 'missing_params' });
+  if (!PKG_RE.test(pkg) || !VER_RE.test(version)) {
+    return res.status(400).json({
+      error: 'invalid_params',
+      message: 'package or version contains disallowed characters',
+    });
+  }
 
   const body = req.body || {};
   if (typeof body.yanked !== 'boolean') {
-    return res.status(400).json({ error: 'invalid_body', message: '`yanked` must be a boolean' });
+    return res.status(400).json({
+      error: 'invalid_body',
+      message: '`yanked` must be a boolean',
+    });
   }
 
-  // Require authenticated user
   const user = await requireAuth(req, res);
-  if (!user) return; // requireAuth sends the 401 itself
+  if (!user) return;
 
   const store = getStorage();
   let existing;
   try {
     existing = await store.getBundleManifest(pkg, version);
   } catch (e) {
-    return res.status(500).json({ error: 'internal_error', message: e?.message ?? String(e) });
+    return res
+      .status(500)
+      .json({ error: 'internal_error', message: e?.message ?? String(e) });
   }
   if (!existing) return res.status(404).json({ error: 'not_found' });
 
-  // Allow if session user owns the package OR the request carries a valid owner pubkey
-  const sigKey = body.signature ? getPublicKeyFromManifest(body) : null;
-  const ownedBySig = sigKey && isAllowedOwner(existing, sigKey);
-  const ownedBySession = manifestOwnedByUser(existing, user);
-
-  if (!ownedBySig && !ownedBySession) {
-    return res.status(403).json({ error: 'not_owner', message: 'Only the package owner can yank this version.' });
+  if (!manifestOwnedByUser(existing, user)) {
+    return res.status(403).json({
+      error: 'not_owner',
+      message: 'Only the package owner can yank this version.',
+    });
   }
 
-  const kv = await getKV();
   const yankKey = `bundle-yanked:${pkg}/${version}`;
 
   try {
@@ -118,6 +89,8 @@ module.exports = async function handler(req, res) {
     }
     return res.status(200).json({ package: pkg, version, yanked: body.yanked });
   } catch (e) {
-    return res.status(500).json({ error: 'internal_error', message: e?.message ?? String(e) });
+    return res
+      .status(500)
+      .json({ error: 'internal_error', message: e?.message ?? String(e) });
   }
 };

--- a/api/v2/bundles/[package]/[version]/yank.js
+++ b/api/v2/bundles/[package]/[version]/yank.js
@@ -11,25 +11,20 @@
 const {
   BundleStorageKV,
 } = require('@calimero-network/registry-backend/src/lib/bundle-storage-kv');
-const { requireAuth } = require('../../../../lib/auth-helpers');
+const {
+  requireAuth,
+  manifestOwnedByUser,
+} = require('../../../../lib/auth-helpers');
 const { kv } = require('../../../../lib/kv-client');
 
-const PKG_RE = /^[\w.@/-]+$/;
+// Scoped packages (@org/name) are allowed; bare path traversal sequences are not.
+const PKG_RE = /^(?:@[\w.-]+\/)?[\w.+-]+$/;
 const VER_RE = /^[\w.+-]+$/;
 
 let _store;
 function getStorage() {
   if (!_store) _store = new BundleStorageKV();
   return _store;
-}
-
-function manifestOwnedByUser(manifest, user) {
-  const author = manifest?.metadata?.author;
-  const ownerEmail = manifest?.metadata?._ownerEmail;
-  if (user?.username && author === user.username) return true;
-  if (user?.email && ownerEmail === user.email) return true;
-  if (user?.email && !user?.username && author === user.email) return true;
-  return false;
 }
 
 module.exports = async function handler(req, res) {
@@ -66,9 +61,8 @@ module.exports = async function handler(req, res) {
   try {
     existing = await store.getBundleManifest(pkg, version);
   } catch (e) {
-    return res
-      .status(500)
-      .json({ error: 'internal_error', message: e?.message ?? String(e) });
+    console.error('yank: getBundleManifest failed', e);
+    return res.status(500).json({ error: 'internal_error' });
   }
   if (!existing) return res.status(404).json({ error: 'not_found' });
 
@@ -89,8 +83,7 @@ module.exports = async function handler(req, res) {
     }
     return res.status(200).json({ package: pkg, version, yanked: body.yanked });
   } catch (e) {
-    return res
-      .status(500)
-      .json({ error: 'internal_error', message: e?.message ?? String(e) });
+    console.error('yank: KV write failed', e);
+    return res.status(500).json({ error: 'internal_error' });
   }
 };

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -112,6 +112,21 @@ module.exports = async function handler(req, res) {
     }
 
     const { all_versions } = req.query || {};
+
+    if (all_versions === 'true' && !pkg) {
+      return res.status(400).json({
+        error: 'invalid_params',
+        message: 'all_versions requires a package parameter',
+      });
+    }
+    if (all_versions === 'true' && (developer || author)) {
+      return res.status(400).json({
+        error: 'invalid_params',
+        message:
+          'all_versions cannot be combined with developer or author filters',
+      });
+    }
+
     const allPackages = await kv.sMembers('bundles:all');
     const rawBundles = [];
     for (const packageName of allPackages) {
@@ -122,9 +137,9 @@ module.exports = async function handler(req, res) {
         semver.rcompare(semver.valid(a) || '0.0.0', semver.valid(b) || '0.0.0')
       );
       if (all_versions === 'true' && pkg) {
-        // Return every non-yanked published version for this specific package (version picker).
+        // Return every published version with yanked status included (used by version picker).
         // yanked flag is stored separately at bundle-yanked:<pkg>/<ver> so it can be
-        // flipped without touching the immutable bundle manifest.
+        // toggled without touching the immutable bundle manifest.
         for (const ver of sorted) {
           const [data, yankFlag] = await Promise.all([
             kv.get(`bundle:${packageName}/${ver}`),
@@ -132,7 +147,10 @@ module.exports = async function handler(req, res) {
           ]);
           if (!data) continue;
           const bundle = JSON.parse(data).json;
-          rawBundles.push({ bundle: { ...bundle, yanked: yankFlag === '1' }, packageName });
+          rawBundles.push({
+            bundle: { ...bundle, yanked: yankFlag === '1' },
+            packageName,
+          });
         }
       } else {
         // Default: return only the latest version per package

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -111,6 +111,7 @@ module.exports = async function handler(req, res) {
       return res.status(200).json([{ ...sanitized, downloads }]);
     }
 
+    const { all_versions } = req.query || {};
     const allPackages = await kv.sMembers('bundles:all');
     const rawBundles = [];
     for (const packageName of allPackages) {
@@ -120,17 +121,28 @@ module.exports = async function handler(req, res) {
       const sorted = versions.sort((a, b) =>
         semver.rcompare(semver.valid(a) || '0.0.0', semver.valid(b) || '0.0.0')
       );
-      const latestVersion = sorted[0];
-      const data = await kv.get(`bundle:${packageName}/${latestVersion}`);
-      if (!data) continue;
-      const bundle = JSON.parse(data).json;
-      if (developer && bundle.signature?.pubkey !== developer) continue;
-      if (author) {
-        const authorIdentity =
-          bundle.metadata?.author ?? bundle.metadata?._ownerEmail;
-        if (authorIdentity !== author) continue;
+      if (all_versions === 'true' && pkg) {
+        // Return every published version for this specific package (version picker)
+        for (const ver of sorted) {
+          const data = await kv.get(`bundle:${packageName}/${ver}`);
+          if (!data) continue;
+          const bundle = JSON.parse(data).json;
+          rawBundles.push({ bundle, packageName });
+        }
+      } else {
+        // Default: return only the latest version per package
+        const latestVersion = sorted[0];
+        const data = await kv.get(`bundle:${packageName}/${latestVersion}`);
+        if (!data) continue;
+        const bundle = JSON.parse(data).json;
+        if (developer && bundle.signature?.pubkey !== developer) continue;
+        if (author) {
+          const authorIdentity =
+            bundle.metadata?.author ?? bundle.metadata?._ownerEmail;
+          if (authorIdentity !== author) continue;
+        }
+        rawBundles.push({ bundle, packageName });
       }
-      rawBundles.push({ bundle, packageName });
     }
 
     // Batch-sanitize all bundles and batch-fetch download counts in parallel

--- a/api/v2/bundles/index.js
+++ b/api/v2/bundles/index.js
@@ -122,12 +122,17 @@ module.exports = async function handler(req, res) {
         semver.rcompare(semver.valid(a) || '0.0.0', semver.valid(b) || '0.0.0')
       );
       if (all_versions === 'true' && pkg) {
-        // Return every published version for this specific package (version picker)
+        // Return every non-yanked published version for this specific package (version picker).
+        // yanked flag is stored separately at bundle-yanked:<pkg>/<ver> so it can be
+        // flipped without touching the immutable bundle manifest.
         for (const ver of sorted) {
-          const data = await kv.get(`bundle:${packageName}/${ver}`);
+          const [data, yankFlag] = await Promise.all([
+            kv.get(`bundle:${packageName}/${ver}`),
+            kv.get(`bundle-yanked:${packageName}/${ver}`),
+          ]);
           if (!data) continue;
           const bundle = JSON.parse(data).json;
-          rawBundles.push({ bundle, packageName });
+          rawBundles.push({ bundle: { ...bundle, yanked: yankFlag === '1' }, packageName });
         }
       } else {
         // Default: return only the latest version per package

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -161,9 +161,9 @@ export const getMyPackages = async (params: {
 };
 
 export const getAppVersions = async (appId: string): Promise<VersionInfo[]> => {
-  // Use V2 Bundle API - get all bundles for this package
+  // Use V2 Bundle API - get all bundles for this package (including yanked)
   const response = await api.get('/v2/bundles', {
-    params: { package: appId },
+    params: { package: appId, all_versions: 'true' },
   });
   const bundles = Array.isArray(response.data) ? response.data : [];
 
@@ -175,7 +175,7 @@ export const getAppVersions = async (appId: string): Promise<VersionInfo[]> => {
     return {
       semver: bundle.appVersion,
       cid: artifactUrl,
-      yanked: false,
+      yanked: bundle.yanked === true,
     };
   });
 };
@@ -267,6 +267,18 @@ export const getBundleManifestRaw = async (
 ): Promise<Record<string, any>> => {
   const response = await api.get(`/v2/bundles/${packageName}/${version}`);
   return response.data;
+};
+
+/** Yank (or unyank) a specific version of a package. Requires login as the package author. */
+export const yankBundleVersion = async (
+  packageName: string,
+  version: string,
+  yanked: boolean
+): Promise<void> => {
+  await api.post(
+    `/v2/bundles/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}/yank`,
+    { yanked }
+  );
 };
 
 /** Delete a specific version of a package. Requires login as the package author. */

--- a/packages/frontend/src/pages/AppDetailPage.tsx
+++ b/packages/frontend/src/pages/AppDetailPage.tsx
@@ -75,6 +75,9 @@ export default function AppDetailPage() {
   const [confirmYankVersion, setConfirmYankVersion] = useState<string | null>(
     null
   );
+  const [confirmUnYankVersion, setConfirmUnYankVersion] = useState<
+    string | null
+  >(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [yankError, setYankError] = useState<string | null>(null);
   const [yankingVersion, setYankingVersion] = useState<string | null>(null);
@@ -474,20 +477,42 @@ export default function AppDetailPage() {
                     )}
                     {isVersionOwner &&
                       (b.yanked ? (
-                        <button
-                          onClick={() => {
-                            setYankingVersion(b.appVersion);
-                            yankVersionMutation.mutate({
-                              version: b.appVersion,
-                              yanked: false,
-                            });
-                          }}
-                          disabled={yankingVersion === b.appVersion}
-                          className='inline-flex items-center gap-1 text-[11px] text-amber-500 hover:text-amber-300 transition-colors disabled:opacity-50'
-                        >
-                          <RotateCcw className='w-3 h-3' />
-                          Unyank
-                        </button>
+                        confirmUnYankVersion === b.appVersion ? (
+                          <span className='flex items-center gap-1.5 text-[11px]'>
+                            <span className='text-amber-400'>Unyank?</span>
+                            <button
+                              onClick={() => {
+                                setConfirmUnYankVersion(null);
+                                setYankingVersion(b.appVersion);
+                                yankVersionMutation.mutate({
+                                  version: b.appVersion,
+                                  yanked: false,
+                                });
+                              }}
+                              disabled={yankingVersion === b.appVersion}
+                              className='text-amber-400 hover:text-amber-300 font-medium transition-colors disabled:opacity-50'
+                            >
+                              Yes
+                            </button>
+                            <button
+                              onClick={() => setConfirmUnYankVersion(null)}
+                              className='text-neutral-500 hover:text-neutral-300 transition-colors'
+                            >
+                              Cancel
+                            </button>
+                          </span>
+                        ) : (
+                          <button
+                            onClick={() =>
+                              setConfirmUnYankVersion(b.appVersion)
+                            }
+                            disabled={yankingVersion === b.appVersion}
+                            className='inline-flex items-center gap-1 text-[11px] text-amber-500 hover:text-amber-300 transition-colors disabled:opacity-50'
+                          >
+                            <RotateCcw className='w-3 h-3' />
+                            Unyank
+                          </button>
+                        )
                       ) : confirmYankVersion === b.appVersion ? (
                         <span className='flex items-center gap-1.5 text-[11px]'>
                           <span className='text-amber-400'>Yank?</span>

--- a/packages/frontend/src/pages/AppDetailPage.tsx
+++ b/packages/frontend/src/pages/AppDetailPage.tsx
@@ -19,11 +19,14 @@ import {
   Building2,
   ArrowRight,
   BadgeCheck,
+  Ban,
+  RotateCcw,
 } from 'lucide-react';
 import {
   api,
   deleteBundleVersion,
   deletePackage,
+  yankBundleVersion,
   getOrgByPackage,
   getOrgMembers,
 } from '@/lib/api';
@@ -34,6 +37,7 @@ interface V2Bundle {
   package: string;
   appVersion: string;
   verified?: boolean;
+  yanked?: boolean;
   metadata?: {
     name?: string;
     description?: string;
@@ -69,12 +73,13 @@ export default function AppDetailPage() {
   >(null);
   const [confirmDeletePackage, setConfirmDeletePackage] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [yankingVersion, setYankingVersion] = useState<string | null>(null);
 
   const { data: allBundles = [], isLoading } = useQuery({
     queryKey: ['app-bundles', appId],
     queryFn: async () => {
       const response = await api.get('/v2/bundles', {
-        params: { package: appId },
+        params: { package: appId, all_versions: 'true' },
       });
       return (Array.isArray(response.data) ? response.data : []) as V2Bundle[];
     },
@@ -115,6 +120,22 @@ export default function AppDetailPage() {
           ?.message || (err instanceof Error ? err.message : 'Delete failed');
       setDeleteError(msg);
       setConfirmDeletePackage(false);
+    },
+  });
+
+  const yankVersionMutation = useMutation({
+    mutationFn: ({ version, yanked }: { version: string; yanked: boolean }) =>
+      yankBundleVersion(appId, version, yanked),
+    onSuccess: () => {
+      setYankingVersion(null);
+      queryClient.invalidateQueries({ queryKey: ['app-bundles', appId] });
+    },
+    onError: (err: unknown) => {
+      setYankingVersion(null);
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message || (err instanceof Error ? err.message : 'Yank failed');
+      setDeleteError(msg);
     },
   });
 
@@ -435,6 +456,38 @@ export default function AppDetailPage() {
                         <Pencil className='w-3 h-3' />
                         Edit
                       </Link>
+                    )}
+                    {b.yanked && (
+                      <span className='pill bg-amber-500/10 text-amber-400 text-[10px]'>
+                        Yanked
+                      </span>
+                    )}
+                    {canEditVersion && (
+                      b.yanked ? (
+                        <button
+                          onClick={() => {
+                            setYankingVersion(b.appVersion);
+                            yankVersionMutation.mutate({ version: b.appVersion, yanked: false });
+                          }}
+                          disabled={yankingVersion === b.appVersion}
+                          className='inline-flex items-center gap-1 text-[11px] text-amber-500 hover:text-amber-300 transition-colors disabled:opacity-50'
+                        >
+                          <RotateCcw className='w-3 h-3' />
+                          Unyank
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => {
+                            setYankingVersion(b.appVersion);
+                            yankVersionMutation.mutate({ version: b.appVersion, yanked: true });
+                          }}
+                          disabled={yankingVersion === b.appVersion}
+                          className='inline-flex items-center gap-1 text-[11px] text-neutral-600 hover:text-amber-400 transition-colors disabled:opacity-50'
+                        >
+                          <Ban className='w-3 h-3' />
+                          Yank
+                        </button>
+                      )
                     )}
                     {isVersionOwner && (
                       <>

--- a/packages/frontend/src/pages/AppDetailPage.tsx
+++ b/packages/frontend/src/pages/AppDetailPage.tsx
@@ -72,7 +72,11 @@ export default function AppDetailPage() {
     string | null
   >(null);
   const [confirmDeletePackage, setConfirmDeletePackage] = useState(false);
+  const [confirmYankVersion, setConfirmYankVersion] = useState<string | null>(
+    null
+  );
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [yankError, setYankError] = useState<string | null>(null);
   const [yankingVersion, setYankingVersion] = useState<string | null>(null);
 
   const { data: allBundles = [], isLoading } = useQuery({
@@ -128,6 +132,7 @@ export default function AppDetailPage() {
       yankBundleVersion(appId, version, yanked),
     onSuccess: () => {
       setYankingVersion(null);
+      setYankError(null);
       queryClient.invalidateQueries({ queryKey: ['app-bundles', appId] });
     },
     onError: (err: unknown) => {
@@ -135,7 +140,7 @@ export default function AppDetailPage() {
       const msg =
         (err as { response?: { data?: { message?: string } } })?.response?.data
           ?.message || (err instanceof Error ? err.message : 'Yank failed');
-      setDeleteError(msg);
+      setYankError(msg);
     },
   });
 
@@ -240,6 +245,11 @@ export default function AppDetailPage() {
       {deleteError && (
         <p className='text-[12px] text-red-400 bg-red-900/20 border border-red-800/40 rounded-lg px-3 py-2'>
           {deleteError}
+        </p>
+      )}
+      {yankError && (
+        <p className='text-[12px] text-amber-400 bg-amber-900/20 border border-amber-800/40 rounded-lg px-3 py-2'>
+          {yankError}
         </p>
       )}
 
@@ -462,12 +472,15 @@ export default function AppDetailPage() {
                         Yanked
                       </span>
                     )}
-                    {canEditVersion && (
-                      b.yanked ? (
+                    {isVersionOwner &&
+                      (b.yanked ? (
                         <button
                           onClick={() => {
                             setYankingVersion(b.appVersion);
-                            yankVersionMutation.mutate({ version: b.appVersion, yanked: false });
+                            yankVersionMutation.mutate({
+                              version: b.appVersion,
+                              yanked: false,
+                            });
                           }}
                           disabled={yankingVersion === b.appVersion}
                           className='inline-flex items-center gap-1 text-[11px] text-amber-500 hover:text-amber-300 transition-colors disabled:opacity-50'
@@ -475,20 +488,40 @@ export default function AppDetailPage() {
                           <RotateCcw className='w-3 h-3' />
                           Unyank
                         </button>
+                      ) : confirmYankVersion === b.appVersion ? (
+                        <span className='flex items-center gap-1.5 text-[11px]'>
+                          <span className='text-amber-400'>Yank?</span>
+                          <button
+                            onClick={() => {
+                              setConfirmYankVersion(null);
+                              setYankingVersion(b.appVersion);
+                              yankVersionMutation.mutate({
+                                version: b.appVersion,
+                                yanked: true,
+                              });
+                            }}
+                            disabled={yankingVersion === b.appVersion}
+                            className='text-amber-400 hover:text-amber-300 font-medium transition-colors disabled:opacity-50'
+                          >
+                            Yes
+                          </button>
+                          <button
+                            onClick={() => setConfirmYankVersion(null)}
+                            className='text-neutral-500 hover:text-neutral-300 transition-colors'
+                          >
+                            Cancel
+                          </button>
+                        </span>
                       ) : (
                         <button
-                          onClick={() => {
-                            setYankingVersion(b.appVersion);
-                            yankVersionMutation.mutate({ version: b.appVersion, yanked: true });
-                          }}
+                          onClick={() => setConfirmYankVersion(b.appVersion)}
                           disabled={yankingVersion === b.appVersion}
                           className='inline-flex items-center gap-1 text-[11px] text-neutral-600 hover:text-amber-400 transition-colors disabled:opacity-50'
                         >
                           <Ban className='w-3 h-3' />
                           Yank
                         </button>
-                      )
-                    )}
+                      ))}
                     {isVersionOwner && (
                       <>
                         {isConfirmingThisVersion ? (


### PR DESCRIPTION
## What

Adds `?all_versions=true` to `GET /api/v2/bundles` so callers can retrieve the full version history of a specific package instead of just the latest.

```
GET /api/v2/bundles?package=com.calimero.mero-drive-docs&all_versions=true
→ [ { appVersion: "9.4.0", ... }, { appVersion: "9.3.0", ... }, ... ]
```

Without the param, behaviour is unchanged: one entry per package (latest only).

## Why

Required by the Tauri desktop app's version picker (tauri-app PR #110). The version picker calls `fetchAppVersions` to populate a dropdown so users can install any historically published version, not just the latest. Previously `fetchAppVersions` hit this endpoint and always received only one result, making the dropdown show nothing useful.

## Changes

- `api/v2/bundles/index.js`: when `all_versions=true && package=<pkg>`, iterate the full `bundle-versions:<pkg>` KV set (already sorted descending by semver) and push every version to `rawBundles` for batch sanitization. Developer/author filters are skipped in this mode since the caller already knows which package they want.

## Validation

- Existing behaviour: `GET /api/v2/bundles` and `GET /api/v2/bundles?package=X` still return one entry per package (latest).
- New behaviour: `GET /api/v2/bundles?package=X&all_versions=true` returns all published versions sorted newest-first.
- No schema changes, no new KV keys — reads from the existing `bundle-versions:<pkg>` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated write path and ownership checks on registry metadata; yank state is advisory (artifacts remain available) but affects how clients present versions.
> 
> **Overview**
> Adds **`?all_versions=true`** on `GET /api/v2/bundles` (with `package`) so clients get every published semver for one package, newest first, instead of only the latest. In that mode each entry includes a **`yanked`** flag read from a separate KV key (`bundle-yanked:<pkg>/<ver>`), without changing stored manifests.
> 
> Introduces **owner-only yank/unyank**: `POST /api/v2/bundles/:package/:version/yank` with `{ yanked: boolean }`, guarded by new **`manifestOwnedByUser`** in auth helpers (username/`_ownerEmail` matching). Yanked versions stay fetchable by direct version GET.
> 
> The **frontend** switches version lists (`getAppVersions`, app detail) to `all_versions=true`, maps real `yanked` state, adds **`yankBundleVersion`**, and lets package owners yank/unyank from version history with confirmation UI and badges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d279d21b31dc77d4d5eb033a1fc3367953e1613b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->