### PR TITLE
chore(deps): bump axios from 1.13.2 to 1.15.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fastify/cors": "^8.4.0",
     "@noble/ed25519": "^2.0.0",
-    "axios": "^1.3.0",
+    "axios": "^1.15.0",
     "bs58": "^5.0.0",
     "canonicalize": "^2.1.0",
     "chalk": "^5.3.0",

--- a/packages/client-library/package.json
+++ b/packages/client-library/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.3.0"
+    "axios": "^1.15.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
     "@calimero-network/mero-ui": "^1.5.0",
     "@noble/ed25519": "^2.0.0",
     "@tanstack/react-query": "^4.29.0",
-    "axios": "^1.3.0",
+    "axios": "^1.15.0",
     "canonicalize": "^2.1.0",
     "clsx": "^1.2.1",
     "lucide-react": "^0.263.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^2.0.0
         version: 2.3.0
       axios:
-        specifier: ^1.3.0
-        version: 1.13.2
+        specifier: ^1.15.0
+        version: 1.17.0
       bs58:
         specifier: ^5.0.0
         version: 5.0.0
@@ -268,8 +268,8 @@ importers:
   packages/client-library:
     dependencies:
       axios:
-        specifier: ^1.3.0
-        version: 1.13.2
+        specifier: ^1.15.0
+        version: 1.17.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.33.0
@@ -338,8 +338,8 @@ importers:
         specifier: ^4.29.0
         version: 4.42.0(react-dom@19.2.3)(react@19.2.3)
       axios:
-        specifier: ^1.3.0
-        version: 1.13.2
+        specifier: ^1.15.0
+        version: 1.17.0
       canonicalize:
         specifier: ^2.1.0
         version: 2.1.0
@@ -3938,6 +3938,15 @@ packages:
     hasBin: true
     dev: true
 
+  /agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4159,14 +4168,16 @@ packages:
       fastq: 1.20.1
     dev: false
 
-  /axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  /axios@1.17.0:
+    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
     dev: false
 
   /babel-jest@29.7.0(@babel/core@7.28.5):
@@ -5944,8 +5955,8 @@ packages:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
     dev: true
 
-  /follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  /follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -6336,6 +6347,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -9290,8 +9311,9 @@ packages:
       ipaddr.js: 1.9.1
     dev: false
 
-  /proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  /proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
     dev: false
 
   /pstree.remy@1.1.8:


### PR DESCRIPTION
Re-opened replacement for #138 (auto-closed by a branch-deletion race during merge). Rebased onto main; axios resolves to 1.17.0 under `^1.15.0`. frontend/cli/client-library tests pass. Original commit by dependabot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no code changes; standard HTTP client upgrade with passing tests noted in the PR.
> 
> **Overview**
> Bumps the shared **axios** dependency from `^1.3.0` to `^1.15.0` in `packages/cli`, `packages/client-library`, and `packages/frontend`, with `pnpm-lock.yaml` updated so installs resolve to **axios 1.17.0** (previously 1.13.2).
> 
> The lockfile also picks up axios’s updated transitive stack (`follow-redirects` 1.16.0, `proxy-from-env` 2.1.0, and `https-proxy-agent` 5.0.1). No application source changes—only manifests and the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c6a159c7150b3a7d4111f91b37464869b1bb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->