### PR TITLE
fix(ci): drop redundant pnpm version input (use packageManager)

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Get pnpm store directory
         shell: bash
@@ -60,8 +58,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Get pnpm store directory
         shell: bash
@@ -99,8 +95,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Get pnpm store directory
         shell: bash
@@ -62,8 +60,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Get pnpm store directory
         shell: bash
@@ -109,8 +105,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/deploy-frontend-pages.yml
+++ b/.github/workflows/deploy-frontend-pages.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-        with: { version: 9 }
       - run: pnpm install --frozen-lockfile
       - name: Build
         working-directory: packages/frontend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -51,8 +51,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

Every workflow's **Setup pnpm** step fails (so `main` and all open dependabot PRs are red) with *"multiple versions of pnpm specified"*. `package.json` declares `"packageManager": "pnpm@8.15.0"`, but each `pnpm/action-setup` step *also* passes an explicit `version:` input — the action rejects having both.

Confirmed via the job step breakdown: `Set up job → Checkout → Setup Node ✓`, then **`Setup pnpm ✗`**, everything after skipped.

## Fix

Remove the redundant `version:` inputs (19 lines across 6 workflows) so `pnpm/action-setup` resolves the version from the `packageManager` field — a single source of truth (8.15.0). Also fixes drift where `deploy-frontend-pages.yml` pinned pnpm 9 against an 8.15.0 lockfile.

## Why now

This is the pre-existing breakage blocking the open dependabot GitHub-Actions bumps (#145–#149); none of those bumps caused it. Merging this first makes CI meaningful again so those can be verified + merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow edits with no application or runtime behavior changes; main risk is misconfigured pnpm version if `packageManager` is wrong.
> 
> **Overview**
> Unblocks CI by removing explicit `version:` inputs from every `pnpm/action-setup@v4` step across six workflows (`basic-ci`, `ci`, `cli-release`, `deploy-frontend-pages`, `deploy`, `semantic-release`). **`pnpm/action-setup` was failing** with *multiple versions of pnpm specified* because root `package.json` already declares `"packageManager": "pnpm@8.15.0"`.
> 
> pnpm is now resolved from that single source of truth everywhere. **`deploy-frontend-pages.yml`** no longer pins pnpm 9, which had drifted from the 8.15.0 lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc2ae51cddbd1cd0eae3c78cdcc26d146bbca99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->