### PR TITLE
feat(backend): store bundle binaries in GCS instead of Redis

### DIFF
--- a/ENV_CONFIG.md
+++ b/ENV_CONFIG.md
@@ -14,6 +14,18 @@ NODE_ENV=production         # Environment (development/production)
 REDIS_URL=redis://...       # Redis connection URL (required in production)
 VERCEL=1                    # Set automatically by Vercel (enables Redis)
 
+# Bundle binary storage — Google Cloud Storage (GCS)
+# Raw .mpk bundle blobs are stored in a GCS bucket (not Redis). Manifests,
+# indexes and counters stay in Redis. Objects are written to {GCS_PREFIX}/{package}/{version}.mpk
+GCS_BUCKET=calimero-app-registry  # Bucket name (required to read/write binaries)
+GCS_PREFIX=bundles                # Object key prefix (default: bundles)
+GCS_PROJECT_ID=                   # GCP project id (optional if inferable from creds)
+# Service-account credentials. On Vercel (no key file on disk) use inline creds:
+GCS_CLIENT_EMAIL=                 # service-account email
+GCS_PRIVATE_KEY=                  # service-account private key (PEM; \n-escaped newlines OK)
+# Or, for local/ADC, leave the two above empty and set:
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
 # Development/Testing
 SEED_TEST_APPS=true         # Seed test apps on startup (default: true in dev, false in prod)
 LOG_LEVEL=info              # Logging level (debug, info, warn, error)
@@ -87,3 +99,8 @@ Vercel automatically sets:
 
 - `REDIS_URL` - When you add Marketplace Redis integration
 - All other variables use defaults or are set in `vercel.json`
+
+Set manually in the Vercel project env for bundle binary storage:
+
+- `GCS_BUCKET`, `GCS_PROJECT_ID`, `GCS_CLIENT_EMAIL`, `GCS_PRIVATE_KEY` (and
+  optionally `GCS_PREFIX`). Without these, publishing/serving bundle binaries fails.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,7 @@
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.3",
+    "@google-cloud/storage": "^7.21.0",
     "@noble/ed25519": "^2.0.0",
     "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",

--- a/packages/backend/src/lib/blob-store.js
+++ b/packages/backend/src/lib/blob-store.js
@@ -1,0 +1,83 @@
+/**
+ * Blob Store — Google Cloud Storage (GCS) wrapper for bundle binaries.
+ *
+ * Mirrors a tiny key/value shape (putBinary / getBinary / deleteBinary) so the
+ * shared BundleStorageKV class can swap the binary backing store from Redis to a
+ * bucket without changing its method contract. Manifests, indexes and counters
+ * stay in Redis; only the raw `.mpk` blob lives here.
+ */
+
+const { Storage } = require('@google-cloud/storage');
+
+const BUCKET = process.env.GCS_BUCKET;
+const PREFIX = process.env.GCS_PREFIX || 'bundles';
+
+/**
+ * Build the GCS client lazily so importing this module never throws when the
+ * bucket isn't configured (e.g. unit tests, or routes that never touch binaries).
+ */
+let _storage;
+let _bucket;
+
+function getBucket() {
+  if (_bucket) return _bucket;
+
+  if (!BUCKET) {
+    throw new Error(
+      'GCS_BUCKET is not set — cannot read/write bundle binaries to Google Cloud Storage'
+    );
+  }
+
+  // Credentials resolution order:
+  // 1. Inline service-account creds via GCS_CLIENT_EMAIL + GCS_PRIVATE_KEY
+  //    (the practical option for Vercel serverless — no key file on disk).
+  // 2. Application Default Credentials (GOOGLE_APPLICATION_CREDENTIALS path,
+  //    workload identity, gcloud auth, etc.) when inline creds are absent.
+  const options = {};
+  if (process.env.GCS_PROJECT_ID) {
+    options.projectId = process.env.GCS_PROJECT_ID;
+  }
+  if (process.env.GCS_CLIENT_EMAIL && process.env.GCS_PRIVATE_KEY) {
+    options.credentials = {
+      client_email: process.env.GCS_CLIENT_EMAIL,
+      // Env vars flatten newlines to the literal "\n"; restore them for the PEM.
+      private_key: process.env.GCS_PRIVATE_KEY.replace(/\\n/g, '\n'),
+    };
+  }
+
+  _storage = new Storage(options);
+  _bucket = _storage.bucket(BUCKET);
+  return _bucket;
+}
+
+const objectKey = pkgVersionKey => `${PREFIX}/${pkgVersionKey}.mpk`;
+
+async function putBinary(pkgVersionKey, buffer) {
+  await getBucket()
+    .file(objectKey(pkgVersionKey))
+    .save(buffer, { contentType: 'application/gzip', resumable: false });
+}
+
+async function getBinary(pkgVersionKey) {
+  // returns Buffer | null
+  // When the bucket isn't configured (offline/local dev), return null so callers
+  // fall back to the legacy Redis copy instead of erroring on every read.
+  if (!BUCKET) return null;
+  try {
+    const [contents] = await getBucket()
+      .file(objectKey(pkgVersionKey))
+      .download();
+    return contents;
+  } catch (err) {
+    if (err?.code === 404) return null;
+    throw err;
+  }
+}
+
+async function deleteBinary(pkgVersionKey) {
+  await getBucket()
+    .file(objectKey(pkgVersionKey))
+    .delete({ ignoreNotFound: true });
+}
+
+module.exports = { putBinary, getBinary, deleteBinary, objectKey };

--- a/packages/backend/src/lib/blob-store.js
+++ b/packages/backend/src/lib/blob-store.js
@@ -9,24 +9,27 @@
 
 const { Storage } = require('@google-cloud/storage');
 
-const BUCKET = process.env.GCS_BUCKET;
-const PREFIX = process.env.GCS_PREFIX || 'bundles';
+// Read GCS config fresh on each access (not captured at module load) so tests
+// and any runtime reconfiguration that mutate process.env are picked up.
+const bucketName = () => process.env.GCS_BUCKET;
+const prefix = () => process.env.GCS_PREFIX || 'bundles';
 
 /**
- * Build the GCS client lazily so importing this module never throws when the
- * bucket isn't configured (e.g. unit tests, or routes that never touch binaries).
+ * Lazily build (and cache) the GCS client + bucket handle. The cache is keyed by
+ * bucket name so a changed GCS_BUCKET rebuilds rather than reusing a stale handle.
  */
 let _storage;
 let _bucket;
+let _bucketName;
 
 function getBucket() {
-  if (_bucket) return _bucket;
-
-  if (!BUCKET) {
+  const name = bucketName();
+  if (!name) {
     throw new Error(
       'GCS_BUCKET is not set — cannot read/write bundle binaries to Google Cloud Storage'
     );
   }
+  if (_bucket && _bucketName === name) return _bucket;
 
   // Credentials resolution order:
   // 1. Inline service-account creds via GCS_CLIENT_EMAIL + GCS_PRIVATE_KEY
@@ -46,11 +49,16 @@ function getBucket() {
   }
 
   _storage = new Storage(options);
-  _bucket = _storage.bucket(BUCKET);
+  _bucket = _storage.bucket(name);
+  _bucketName = name;
   return _bucket;
 }
 
-const objectKey = pkgVersionKey => `${PREFIX}/${pkgVersionKey}.mpk`;
+const objectKey = pkgVersionKey => `${prefix()}/${pkgVersionKey}.mpk`;
+
+/** True when a GCS error means "object not found" across SDK error shapes. */
+const isNotFound = err =>
+  err?.code === 404 || err?.code === '404' || err?.status === 404;
 
 async function putBinary(pkgVersionKey, buffer) {
   await getBucket()
@@ -62,22 +70,38 @@ async function getBinary(pkgVersionKey) {
   // returns Buffer | null
   // When the bucket isn't configured (offline/local dev), return null so callers
   // fall back to the legacy Redis copy instead of erroring on every read.
-  if (!BUCKET) return null;
+  if (!bucketName()) return null;
   try {
     const [contents] = await getBucket()
       .file(objectKey(pkgVersionKey))
       .download();
     return contents;
   } catch (err) {
-    if (err?.code === 404) return null;
+    if (isNotFound(err)) return null;
     throw err;
   }
 }
 
 async function deleteBinary(pkgVersionKey) {
+  // Mirror getBinary: no bucket configured → nothing to delete (don't throw, so
+  // callers like deleteBundleVersion can still clean up Redis + indexes).
+  if (!bucketName()) return;
   await getBucket()
     .file(objectKey(pkgVersionKey))
     .delete({ ignoreNotFound: true });
 }
 
-module.exports = { putBinary, getBinary, deleteBinary, objectKey };
+/** Test hook: drop the cached client so a later call rebuilds from current env. */
+function _resetForTests() {
+  _storage = undefined;
+  _bucket = undefined;
+  _bucketName = undefined;
+}
+
+module.exports = {
+  putBinary,
+  getBinary,
+  deleteBinary,
+  objectKey,
+  _resetForTests,
+};

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -5,6 +5,7 @@
  */
 
 const { kv } = require('./kv-client');
+const blob = require('./blob-store');
 const semver = require('semver');
 
 class BundleStorageKV {
@@ -105,9 +106,9 @@ class BundleStorageKV {
     // 5. Global bundles list
     await kv.sAdd('bundles:all', manifest.package);
 
-    // 6. Store binary if provided (as hex string)
+    // 6. Store binary in GCS (arrives as a hex string to preserve the contract)
     if (_binary) {
-      await kv.set(`binary:${key}`, _binary);
+      await blob.putBinary(key, Buffer.from(_binary, 'hex'));
     }
 
     return manifestData;
@@ -117,8 +118,13 @@ class BundleStorageKV {
    * Get V2 Bundle Binary by package and version
    */
   async getBundleBinary(pkg, version) {
-    const key = `binary:${pkg}/${version}`;
-    return await kv.get(key);
+    const key = `${pkg}/${version}`;
+    // Read from GCS first; return a hex string so the artifact route's
+    // `Buffer.from(binaryHex, 'hex')` decode stays unchanged.
+    const buf = await blob.getBinary(key);
+    if (buf) return buf.toString('hex');
+    // Backward-compat: legacy bundles whose binary is still in Redis.
+    return await kv.get(`binary:${key}`);
   }
 
   /**
@@ -215,7 +221,8 @@ class BundleStorageKV {
 
     // Remove manifest and binary
     await kv.del(`bundle:${key}`);
-    await kv.del(`binary:${key}`);
+    await kv.del(`binary:${key}`); // clears legacy Redis copy if present
+    await blob.deleteBinary(key); // clears GCS object
 
     // Remove from version set
     await kv.sRem(`bundle-versions:${pkg}`, version);

--- a/packages/backend/src/lib/bundle-storage-kv.js
+++ b/packages/backend/src/lib/bundle-storage-kv.js
@@ -55,6 +55,14 @@ class BundleStorageKV {
       }
     }
 
+    // Upload the binary to GCS BEFORE writing the manifest, so a manifest can
+    // never exist in Redis without its blob in the bucket. If the upload throws,
+    // we bail out here and nothing is written. (Re-uploading the same
+    // package@version is idempotent — identical, immutable bytes to the same key.)
+    if (_binary) {
+      await blob.putBinary(key, Buffer.from(_binary, 'hex'));
+    }
+
     const bundleKey = `bundle:${key}`;
 
     if (overwrite) {
@@ -105,11 +113,6 @@ class BundleStorageKV {
 
     // 5. Global bundles list
     await kv.sAdd('bundles:all', manifest.package);
-
-    // 6. Store binary in GCS (arrives as a hex string to preserve the contract)
-    if (_binary) {
-      await blob.putBinary(key, Buffer.from(_binary, 'hex'));
-    }
 
     return manifestData;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.3
         version: 5.2.6
+      '@google-cloud/storage':
+        specifier: ^7.21.0
+        version: 7.21.0
       '@noble/ed25519':
         specifier: ^2.0.0
         version: 2.3.0
@@ -1443,6 +1446,47 @@ packages:
     dev: false
     optional: true
 
+  /@google-cloud/paginator@5.0.2:
+    resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      arrify: 2.0.1
+      extend: 3.0.2
+    dev: false
+
+  /@google-cloud/projectify@4.0.0:
+    resolution: {integrity: sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /@google-cloud/promisify@4.0.0:
+    resolution: {integrity: sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==}
+    engines: {node: '>=14'}
+    dev: false
+
+  /@google-cloud/storage@7.21.0:
+    resolution: {integrity: sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      abort-controller: 3.0.0
+      async-retry: 1.3.3
+      duplexify: 4.1.3
+      fast-xml-parser: 5.9.2
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
+      html-entities: 2.6.0
+      mime: 3.0.0
+      p-limit: 3.1.0
+      retry-request: 7.0.2
+      teeny-request: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /@humanfs/core@0.19.1:
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1962,6 +2006,10 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
     dev: true
+
+  /@nodable/entities@2.2.0:
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2969,6 +3017,11 @@ packages:
       '@tiptap/pm': 3.14.0
     dev: false
 
+  /@tootallnate/once@2.0.1:
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+    dev: false
+
   /@tybys/wasm-util@0.10.2:
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
     requiresBuild: true
@@ -3009,6 +3062,10 @@ packages:
     dependencies:
       '@babel/types': 7.28.5
     dev: true
+
+  /@types/caseless@0.12.5:
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+    dev: false
 
   /@types/chai@5.2.3:
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -3110,6 +3167,15 @@ packages:
     dependencies:
       csstype: 3.2.3
 
+  /@types/request@2.48.13:
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 20.19.27
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.6
+    dev: false
+
   /@types/semver@7.7.1:
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
     dev: true
@@ -3130,6 +3196,10 @@ packages:
     dependencies:
       '@types/jest': 30.0.0
     dev: true
+
+  /@types/tough-cookie@4.0.5:
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+    dev: false
 
   /@types/use-sync-external-store@0.0.6:
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -3744,7 +3814,6 @@ packages:
   /agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-    dev: true
 
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -3863,6 +3932,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /anynum@1.0.0:
+    resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
+    dev: false
+
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
     dev: true
@@ -3913,6 +3986,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /arrify@2.0.1:
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
+    dev: false
+
   /asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
     dev: true
@@ -3925,6 +4003,12 @@ packages:
   /astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+    dev: false
+
+  /async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+    dependencies:
+      retry: 0.13.1
     dev: false
 
   /asynckit@0.4.0:
@@ -4072,6 +4156,10 @@ packages:
   /before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
     dev: true
+
+  /bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+    dev: false
 
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -4905,6 +4993,15 @@ packages:
       readable-stream: 2.3.8
     dev: true
 
+  /duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+    dev: false
+
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -4948,6 +5045,12 @@ packages:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
     dependencies:
       iconv-lite: 0.6.3
+    dev: false
+
+  /end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+    dependencies:
+      once: 1.4.0
     dev: false
 
   /entities@4.5.0:
@@ -5434,6 +5537,10 @@ packages:
       jest-util: 30.4.1
     dev: true
 
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
   /fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
     dev: true
@@ -5505,6 +5612,25 @@ packages:
 
   /fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+    dev: false
+
+  /fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+    dev: false
+
+  /fast-xml-parser@5.9.2:
+    resolution: {integrity: sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w==}
+    hasBin: true
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.0
+      xml-naming: 0.1.0
     dev: false
 
   /fastify-plugin@5.1.0:
@@ -5700,6 +5826,18 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
+  /form-data@2.5.6:
+    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
+    engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+    dev: false
+
   /form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -5769,6 +5907,32 @@ packages:
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
+
+  /gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -5916,6 +6080,26 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+    dev: false
+
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -5931,6 +6115,17 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
+
+  /gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -5990,6 +6185,13 @@ packages:
     dependencies:
       function-bind: 1.1.2
 
+  /hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: false
+
   /hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
     dev: true
@@ -6034,6 +6236,10 @@ packages:
       whatwg-encoding: 3.1.1
     dev: true
 
+  /html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+    dev: false
+
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
@@ -6047,6 +6253,17 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+    dev: false
+
+  /http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /http-proxy-agent@7.0.2:
@@ -6077,7 +6294,6 @@ packages:
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -6529,7 +6745,6 @@ packages:
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -6574,6 +6789,10 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
     dev: true
+
+  /is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+    dev: false
 
   /is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -7218,6 +7437,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dev: true
+
+  /json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+    dependencies:
+      bignumber.js: 9.3.1
+    dev: false
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -8135,7 +8360,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -8252,7 +8476,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
-    dev: true
 
   /p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
@@ -8389,6 +8612,11 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
     dev: true
+
+  /path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+    dev: false
 
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -9238,6 +9466,23 @@ packages:
     resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
     dev: false
 
+  /retry-request@7.0.2:
+    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@types/request': 2.48.13
+      extend: 3.0.2
+      teeny-request: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+    dev: false
+
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -9696,6 +9941,16 @@ packages:
       readable-stream: 2.3.8
     dev: true
 
+  /stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+    dependencies:
+      stubs: 3.0.0
+    dev: false
+
+  /stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+    dev: false
+
   /stream-to-it@0.2.4:
     resolution: {integrity: sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==}
     dependencies:
@@ -9832,6 +10087,16 @@ packages:
     dependencies:
       js-tokens: 9.0.1
     dev: true
+
+  /strnum@2.4.0:
+    resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
+    dependencies:
+      anynum: 1.0.0
+    dev: false
+
+  /stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+    dev: false
 
   /sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -9991,6 +10256,20 @@ packages:
       minipass: 7.1.2
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  /teeny-request@9.0.0:
+    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
+    engines: {node: '>=14'}
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      stream-events: 1.0.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
@@ -10480,6 +10759,12 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+    dev: false
+
   /v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -10796,7 +11081,6 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
@@ -10823,6 +11107,11 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
     dev: true
+
+  /xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+    dev: false
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -10911,7 +11200,6 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true
 
   /yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}

--- a/scripts/migrate-binaries-to-gcs.js
+++ b/scripts/migrate-binaries-to-gcs.js
@@ -1,0 +1,98 @@
+/**
+ * One-off migration: move bundle binaries from Redis (`binary:*` hex strings)
+ * into Google Cloud Storage, then drop the Redis copy to reclaim space.
+ *
+ * Idempotent and re-runnable:
+ *   - For each `binary:*` key, upload the decoded bytes to GCS.
+ *   - Verify the GCS object exists (getBinary non-null).
+ *   - Only then delete the Redis key.
+ * Already-migrated bundles (Redis key gone) are simply skipped.
+ *
+ * Usage:
+ *   node scripts/migrate-binaries-to-gcs.js          # migrate + delete Redis keys
+ *   node scripts/migrate-binaries-to-gcs.js --dry-run # report only, no writes
+ *
+ * Requires the same env as the backend: REDIS_URL + GCS_* vars.
+ */
+
+const { kv } = require('../packages/backend/src/lib/kv-client');
+const blob = require('../packages/backend/src/lib/blob-store');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function scanBinaryKeys() {
+  // Prefer SCAN (non-blocking) where the client exposes it; fall back to keys().
+  if (typeof kv.scan === 'function') {
+    const found = [];
+    let cursor = '0';
+    do {
+      const res = await kv.scan(cursor, { MATCH: 'binary:*', COUNT: 100 });
+      // node-redis returns { cursor, keys }; some wrappers return [cursor, keys]
+      const nextCursor = res.cursor ?? res[0];
+      const keys = res.keys ?? res[1] ?? [];
+      found.push(...keys);
+      cursor = String(nextCursor);
+    } while (cursor !== '0');
+    return found;
+  }
+  if (typeof kv.keys === 'function') {
+    return await kv.keys('binary:*');
+  }
+  throw new Error('kv client exposes neither scan() nor keys()');
+}
+
+async function main() {
+  console.log(
+    `Migrating bundle binaries Redis → GCS${DRY_RUN ? ' (dry run)' : ''}...`
+  );
+
+  const keys = await scanBinaryKeys();
+  console.log(`Found ${keys.length} binary:* key(s) in Redis.`);
+
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const redisKey of keys) {
+    // `binary:{package}/{version}` → `{package}/{version}`
+    const pkgVersionKey = redisKey.replace(/^binary:/, '');
+    try {
+      const hex = await kv.get(redisKey);
+      if (!hex) {
+        skipped++;
+        continue;
+      }
+
+      if (DRY_RUN) {
+        console.log(
+          `  would migrate ${pkgVersionKey} (${hex.length / 2} bytes)`
+        );
+        migrated++;
+        continue;
+      }
+
+      await blob.putBinary(pkgVersionKey, Buffer.from(hex, 'hex'));
+
+      // Verify before deleting the source of truth.
+      const check = await blob.getBinary(pkgVersionKey);
+      if (!check) {
+        throw new Error('GCS object missing after upload');
+      }
+
+      await kv.del(redisKey);
+      migrated++;
+      console.log(`  migrated ${pkgVersionKey}`);
+    } catch (err) {
+      failed++;
+      console.error(`  FAILED ${pkgVersionKey}: ${err.message}`);
+    }
+  }
+
+  console.log(`Done. migrated=${migrated} skipped=${skipped} failed=${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Migration crashed:', err);
+  process.exit(1);
+});

--- a/scripts/migrate-binaries-to-gcs.js
+++ b/scripts/migrate-binaries-to-gcs.js
@@ -4,49 +4,46 @@
  *
  * Idempotent and re-runnable:
  *   - For each `binary:*` key, upload the decoded bytes to GCS.
- *   - Verify the GCS object exists (getBinary non-null).
+ *   - Verify the GCS object exists AND its byte length matches the source.
  *   - Only then delete the Redis key.
  * Already-migrated bundles (Redis key gone) are simply skipped.
  *
- * Usage:
+ * Run from the repo root so the relative requires below resolve:
  *   node scripts/migrate-binaries-to-gcs.js          # migrate + delete Redis keys
  *   node scripts/migrate-binaries-to-gcs.js --dry-run # report only, no writes
  *
- * Requires the same env as the backend: REDIS_URL + GCS_* vars.
+ * Requires the same env as the backend: REDIS_URL + GCS_* vars (validated below).
  */
+
+// Fail loudly if required env is missing — these modules read process.env on
+// load, and a missing var could otherwise point at the wrong Redis/GCS silently.
+const REQUIRED_ENV = [
+  'REDIS_URL',
+  'GCS_BUCKET',
+  'GCS_CLIENT_EMAIL',
+  'GCS_PRIVATE_KEY',
+];
+const missing = REQUIRED_ENV.filter(v => !process.env[v]);
+if (missing.length) {
+  console.error(
+    `Refusing to run: missing required env var(s): ${missing.join(', ')}.\n` +
+      'Set them (e.g. via packages/backend/.env) and re-run from the repo root.'
+  );
+  process.exit(1);
+}
 
 const { kv } = require('../packages/backend/src/lib/kv-client');
 const blob = require('../packages/backend/src/lib/blob-store');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
-async function scanBinaryKeys() {
-  // Prefer SCAN (non-blocking) where the client exposes it; fall back to keys().
-  if (typeof kv.scan === 'function') {
-    const found = [];
-    let cursor = '0';
-    do {
-      const res = await kv.scan(cursor, { MATCH: 'binary:*', COUNT: 100 });
-      // node-redis returns { cursor, keys }; some wrappers return [cursor, keys]
-      const nextCursor = res.cursor ?? res[0];
-      const keys = res.keys ?? res[1] ?? [];
-      found.push(...keys);
-      cursor = String(nextCursor);
-    } while (cursor !== '0');
-    return found;
-  }
-  if (typeof kv.keys === 'function') {
-    return await kv.keys('binary:*');
-  }
-  throw new Error('kv client exposes neither scan() nor keys()');
-}
-
 async function main() {
   console.log(
     `Migrating bundle binaries Redis → GCS${DRY_RUN ? ' (dry run)' : ''}...`
   );
 
-  const keys = await scanBinaryKeys();
+  // The backend Redis wrapper exposes scanKeys(pattern) -> string[] of keys.
+  const keys = await kv.scanKeys('binary:*');
   console.log(`Found ${keys.length} binary:* key(s) in Redis.`);
 
   let migrated = 0;
@@ -71,12 +68,19 @@ async function main() {
         continue;
       }
 
-      await blob.putBinary(pkgVersionKey, Buffer.from(hex, 'hex'));
+      const buf = Buffer.from(hex, 'hex');
+      await blob.putBinary(pkgVersionKey, buf);
 
-      // Verify before deleting the source of truth.
+      // Verify before deleting the source of truth: object must exist AND its
+      // byte length must match, so a partial/corrupt upload can't cause data loss.
       const check = await blob.getBinary(pkgVersionKey);
       if (!check) {
         throw new Error('GCS object missing after upload');
+      }
+      if (check.length !== buf.length) {
+        throw new Error(
+          `GCS content length mismatch (expected ${buf.length}, got ${check.length})`
+        );
       }
 
       await kv.del(redisKey);


### PR DESCRIPTION
## Goal

The registry stored every uploaded `.mpk` bundle **as a hex string inside Redis** (`binary:{package}/{version}`). Hex doubles the byte size, so a 1 MB bundle costs ~2 MB of Redis and the 30 MB free tier fills after a handful of bundles.

**Fix:** store the binary blob in a **Google Cloud Storage bucket** instead of Redis. The registry keeps acting as the stream-through **proxy** — it uploads to GCS on publish and reads back from GCS when an artifact is requested. Everything else (manifests, version indexes, download counts, interface indexes, org/user/admin data) **stays in Redis exactly as is.**

> Note: the original plan targeted AWS S3; this implementation uses **GCS** per the team's preference. Same proxy semantics, no egress redirect.

## What changed (storage-only)

The whole change goes through the single shared class `bundle-storage-kv.js`, preserving its method contract so **no route, handler, client, CLI, or frontend code changes**:

- **New** `packages/backend/src/lib/blob-store.js` — tiny GCS wrapper (`putBinary` / `getBinary` / `deleteBinary` / `objectKey`). Lazy client init; supports inline service-account creds (`GCS_CLIENT_EMAIL` + `GCS_PRIVATE_KEY`, ideal for Vercel) or ADC.
- **`bundle-storage-kv.js`**:
  - Write: publish stores the blob in GCS (`_binary` still arrives as a hex string).
  - Read: `getBundleBinary` reads GCS-first and **returns a hex string** (artifact route's `Buffer.from(hex)` decode unchanged), with a **Redis fallback** so pre-migration bundles still serve.
  - Delete: clears both the GCS object and any legacy Redis key.
- **`@google-cloud/storage`** dependency added; lockfile updated (Vercel uses `--frozen-lockfile`).
- **`scripts/migrate-binaries-to-gcs.js`** — idempotent one-off migration (SCAN `binary:*` → upload to GCS → verify → delete Redis key; `--dry-run` supported).
- **`ENV_CONFIG.md`** — documents `GCS_BUCKET`, `GCS_PREFIX`, `GCS_PROJECT_ID`, `GCS_CLIENT_EMAIL`, `GCS_PRIVATE_KEY`.

Objects land at `{GCS_PREFIX}/{package}/{version}.mpk` (default prefix `bundles`).

## Backward compatibility

- `getBundleBinary` falls back to the Redis hex copy, so **old bundles keep working with no migration required**.
- When `GCS_BUCKET` is unset (offline/local dev), reads return null → Redis fallback serves; writes fail loudly (real misconfiguration shouldn't be swallowed).
- Run `scripts/migrate-binaries-to-gcs.js` to actually reclaim Redis space.

## Verification

- `pnpm install && pnpm build:backend` clean.
- `pnpm --filter registry-backend lint` clean; prettier clean.
- Backend test suite: **58 passed / 58**.
- Module smoke test: exports correct, `objectKey('com.foo/1.2.3')` → `bundles/com.foo/1.2.3.mpk`, `getBinary` returns null with no bucket configured.

## Deploy note

Set `GCS_BUCKET`, `GCS_PROJECT_ID`, `GCS_CLIENT_EMAIL`, `GCS_PRIVATE_KEY` (and optionally `GCS_PREFIX`) in the Vercel project env before merging to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production artifact storage path and requires correct GCS credentials at deploy; misconfiguration can break publish/serve until env is set, though legacy Redis binaries remain readable via fallback.
> 
> **Overview**
> Moves **`.mpk` bundle binaries** off Redis (hex `binary:*` keys) into **Google Cloud Storage**, while manifests and indexes stay in Redis. The registry still proxies publish/download through the same storage API—no route or client changes.
> 
> A new **`blob-store`** module wraps GCS (`putBinary` / `getBinary` / `deleteBinary`) with Vercel-friendly inline service-account env vars or ADC. **`bundle-storage-kv`** uploads to GCS **before** writing the manifest, stops persisting binaries in Redis on publish, reads GCS-first (still returns hex for existing artifact decoding), and deletes both GCS and any legacy Redis key on removal.
> 
> Adds **`@google-cloud/storage`**, documents **`GCS_*`** in **`ENV_CONFIG.md`**, and an idempotent **`scripts/migrate-binaries-to-gcs.js`** (verify upload, then delete Redis) to reclaim space. Without **`GCS_BUCKET`** in prod, new publishes fail; reads can still use Redis for unmigrated bundles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46306876a601f4eeaf1e589323dd6f910e7fa42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->