### PR TITLE
chore(deps): bump semver from 7.7.3 to 7.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "jsonwebtoken": "^9.0.3",
     "node-fetch": "^3.3.2",
     "redis": "^5.9.0",
-    "semver": "^7.5.4",
+    "semver": "^7.8.5",
     "busboy": "^1.6.0",
     "tar": "^7.5.11",
     "multibase": "^4.0.0"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -42,7 +42,7 @@
     "multiformats": "^13.4.1",
     "node-fetch": "^3.3.2",
     "pino": "^8.16.0",
-    "semver": "^7.5.4",
+    "semver": "^7.8.5",
     "tar": "^7.5.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^5.9.0
         version: 5.10.0
       semver:
-        specifier: ^7.5.4
-        version: 7.7.3
+        specifier: ^7.8.5
+        version: 7.8.5
       tar:
         specifier: ^7.5.11
         version: 7.5.16
@@ -146,8 +146,8 @@ importers:
         specifier: ^8.16.0
         version: 8.21.0
       semver:
-        specifier: ^7.5.4
-        version: 7.7.3
+        specifier: ^7.8.5
+        version: 7.8.5
       tar:
         specifier: ^7.5.11
         version: 7.5.16
@@ -2539,7 +2539,7 @@ packages:
       read-pkg: 10.0.0
       registry-auth-token: 5.1.0
       semantic-release: 25.0.2(typescript@5.9.3)
-      semver: 7.7.3
+      semver: 7.8.5
       tempy: 3.1.0
     dev: true
 
@@ -3237,7 +3237,7 @@ packages:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.7.3
+      semver: 7.8.5
       ts-api-utils: 1.4.3(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3408,7 +3408,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.7.3
+      semver: 7.8.5
       ts-api-utils: 1.4.3(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3427,7 +3427,7 @@ packages:
       '@typescript-eslint/visitor-keys': 8.50.1
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 9.0.5
-      semver: 7.7.3
+      semver: 7.8.5
       tinyglobby: 0.2.15
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -3448,7 +3448,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       eslint: 8.57.1
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5653,7 +5653,7 @@ packages:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.7.3
+      semver: 7.8.5
       toad-cache: 3.7.0
     dev: false
 
@@ -6848,7 +6848,7 @@ packages:
       '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7288,7 +7288,7 @@ packages:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.7.3
+      semver: 7.8.5
       synckit: 0.11.11
     transitivePeerDependencies:
       - supports-color
@@ -7521,7 +7521,7 @@ packages:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.3
+      semver: 7.8.5
     dev: false
 
   /jwa@2.0.1:
@@ -7802,7 +7802,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
     dev: true
 
   /makeerror@1.0.12:
@@ -8167,7 +8167,7 @@ packages:
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
-      semver: 7.7.3
+      semver: 7.8.5
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -8189,7 +8189,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.7.3
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -8198,7 +8198,7 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     dependencies:
       hosted-git-info: 9.0.2
-      semver: 7.7.3
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -9619,7 +9619,7 @@ packages:
       p-reduce: 3.0.0
       read-package-up: 12.0.0
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       semver-diff: 5.0.0
       signale: 1.4.0
       yargs: 18.0.0
@@ -9633,7 +9633,7 @@ packages:
     engines: {node: '>=12'}
     deprecated: Deprecated as the semver package now supports this built-in.
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
     dev: true
 
   /semver-regex@4.0.5:
@@ -9651,8 +9651,8 @@ packages:
     hasBin: true
     dev: true
 
-  /semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  /semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -9763,7 +9763,7 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
     dev: true
 
   /sirv@3.0.2:
@@ -10135,7 +10135,7 @@ packages:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.14.0
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Rebased replacement for #162 (dependabot branch CI wasn't re-triggering on non-dependabot pushes). Full lockfile regen so frozen install matches updated pnpm.overrides. Verified locally: pnpm install --frozen-lockfile, pnpm quality, pnpm build all pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level semver release with only manifest and lockfile edits; behavior for version compare/sort paths should stay compatible within the same major line.
> 
> **Overview**
> Bumps the **`semver`** dependency from **7.7.3** to **7.8.5** in the root `package.json` and `packages/backend/package.json`, with **`pnpm-lock.yaml`** updated so resolved versions (including transitive uses) point at **7.8.5** instead of **7.7.3**.
> 
> This is a routine in-range upgrade on the existing `^7.x` constraint; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de0eeb06dd7511370d42c40743e73386dd05d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->