### PR TITLE
fix(frontend): bump react-dom to 19.2.7 to match react (fixes React #527)

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.263.1",
     "react": "^19.2.7",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.7",
     "react-router-dom": "^6.8.0",
     "tailwind-merge": "^3.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,7 +333,7 @@ importers:
         version: 0.0.5
       '@calimero-network/mero-ui':
         specifier: ^1.5.0
-        version: 1.5.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.3)(react@19.2.7)
+        version: 1.5.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.7)(react@19.2.7)
       '@noble/ed25519':
         specifier: ^3.1.0
         version: 3.1.0
@@ -356,11 +356,11 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.2.0
-        version: 19.2.3(react@19.2.7)
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       react-router-dom:
         specifier: ^6.8.0
-        version: 6.30.2(react-dom@19.2.3)(react@19.2.7)
+        version: 6.30.2(react-dom@19.2.7)(react@19.2.7)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -373,7 +373,7 @@ importers:
         version: 5.17.0
       '@testing-library/react':
         specifier: ^13.4.0
-        version: 13.4.0(@types/react@19.2.7)(react-dom@19.2.3)(react@19.2.7)
+        version: 13.4.0(@types/react@19.2.7)(react-dom@19.2.7)(react@19.2.7)
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.7
@@ -827,7 +827,7 @@ packages:
     resolution: {integrity: sha512-kHR3lyI0e0Cd9EQLAGkv3++jbuuQ0lIRujGaukHSFyMTsywQxi0zAt7eJ0FtBK72A8ZiliWDI+wpoRXWDwFttw==}
     dev: false
 
-  /@calimero-network/mero-ui@1.5.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.3)(react@19.2.7):
+  /@calimero-network/mero-ui@1.5.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.7)(react@19.2.7):
     resolution: {integrity: sha512-R9VJfOCvZLtwUXFKDOQCnsrbMVGeyT+osawX3VHh/hHQCLtevXKhzZYRhAPaHVo8m1K2Sz8Kxq9qXbfL3rBuQA==}
     peerDependencies:
       react: '>=19.0.0'
@@ -839,10 +839,10 @@ packages:
       '@tiptap/extension-text-align': 3.14.0(@tiptap/core@3.27.1)
       '@tiptap/extension-text-style': 3.14.0(@tiptap/core@3.27.1)
       '@tiptap/extension-underline': 3.14.0(@tiptap/core@3.27.1)
-      '@tiptap/react': 3.14.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.3)(react@19.2.7)
+      '@tiptap/react': 3.14.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.7)(react@19.2.7)
       '@tiptap/starter-kit': 3.14.0
       react: 19.2.7
-      react-dom: 19.2.3(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@floating-ui/dom'
       - '@tiptap/core'
@@ -2635,7 +2635,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react@13.4.0(@types/react@19.2.7)(react-dom@19.2.3)(react@19.2.7):
+  /@testing-library/react@13.4.0(@types/react@19.2.7)(react-dom@19.2.7)(react@19.2.7):
     resolution: {integrity: sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -2646,7 +2646,7 @@ packages:
       '@testing-library/dom': 8.20.1
       '@types/react-dom': 18.3.7(@types/react@19.2.7)
       react: 19.2.7
-      react-dom: 19.2.3(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
     dev: true
@@ -2965,7 +2965,7 @@ packages:
       prosemirror-view: 1.41.9
     dev: false
 
-  /@tiptap/react@3.14.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.3)(react@19.2.7):
+  /@tiptap/react@3.14.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.7)(react@19.2.7):
     resolution: {integrity: sha512-Eo/nLyKxHvnLIF4gI2WFhGJiVrqfA6XL9kismVG9NwBNF/NblMDmZZu6Z2SH/ONJQz2Egn7UBPNp3BMq/qZDcg==}
     peerDependencies:
       '@tiptap/core': ^3.14.0
@@ -2982,7 +2982,7 @@ packages:
       '@types/use-sync-external-store': 0.0.6
       fast-equals: 5.4.0
       react: 19.2.7
-      react-dom: 19.2.3(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.27.1(@tiptap/core@3.27.1)(@tiptap/pm@3.27.1)
@@ -8961,10 +8961,10 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-dom@19.2.3(react@19.2.7):
-    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
+  /react-dom@19.2.7(react@19.2.7):
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.2.3
+      react: ^19.2.7
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
@@ -8992,7 +8992,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom@6.30.2(react-dom@19.2.3)(react@19.2.7):
+  /react-router-dom@6.30.2(react-dom@19.2.7)(react@19.2.7):
     resolution: {integrity: sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -9001,7 +9001,7 @@ packages:
     dependencies:
       '@remix-run/router': 1.23.1
       react: 19.2.7
-      react-dom: 19.2.3(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
       react-router: 6.30.2(react@19.2.7)
     dev: false
 


### PR DESCRIPTION
## Problem
Production (main) throws `Minified React error #527` (args 19.2.7 / 19.2.3) — a react/react-dom version mismatch. #168 bumped `react` to 19.2.7 but `react-dom` stayed locked at 19.2.3. React 19 requires both to be the exact same version.

## Fix
Bump `react-dom` spec to `^19.2.7` and regenerate the lockfile so it resolves to 19.2.7, matching react.

Note: `@types/react-dom` stays at 19.2.3 (its latest published version — @types version independently and don't affect runtime).

Verified: `pnpm install --frozen-lockfile`, `pnpm build` pass; frontend importer now resolves `react-dom 19.2.7(react@19.2.7)`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version alignment only; no application logic changes, with low regression risk beyond standard React patch behavior.
> 
> **Overview**
> Aligns **`react-dom`** with **`react`** at **19.2.7** in `packages/frontend` by changing the dependency from `^19.2.0` to `^19.2.7` and refreshing **`pnpm-lock.yaml`**.
> 
> This removes the **19.2.7 / 19.2.3** runtime pair that triggers **minified React error #527** in production. Lockfile entries for packages that peer on `react-dom` (e.g. `@calimero-network/mero-ui`, `react-router-dom`, `@testing-library/react`) now resolve against **19.2.7** as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5830f63d87dd557fac6bd796058da6641f136d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->