### PR TITLE
fix(client): add repository field so npm provenance validation passes

### DIFF
--- a/packages/client-library/package.json
+++ b/packages/client-library/package.json
@@ -64,5 +64,10 @@
     "javascript"
   ],
   "author": "Calimero Network",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/calimero-network/app-registry.git",
+    "directory": "packages/client-library"
+  }
 }


### PR DESCRIPTION
npm publish of `@calimero-network/registry-client` fails sigstore provenance validation with E422 because `packages/client-library/package.json` has no `repository` field to match against `https://github.com/calimero-network/app-registry` from the provenance bundle.

This has been failing silently for a while: every client-library release since 1.0.1 created a git tag (now at `lib-v1.5.1`) but never reached npm (latest published is 1.0.1). Today's dependabot merges (#172, #176) touched the package and made the Semantic Release job fail visibly on `main`.

Fix mirrors the `repository` field the cli package already declares, plus `directory` for the monorepo path. The next release-triggering commit should publish cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)